### PR TITLE
Make the alerta mailer use of an MTA optional

### DIFF
--- a/integrations/mailer/README.md
+++ b/integrations/mailer/README.md
@@ -12,7 +12,16 @@ It is specifically designed to reduce the number of unnecessary emails by ensuri
 
 To achieve the above, alerts are actually held for a minimum of 30 seconds before they generate emails.
 
-Note: Currently only Google Gmail is supported as the SMTP server. You will need to create an application-specific password.
+If you are using Google Gmail as the SMTP server. You will need to create an application-specific password.
+
+You can skip the use of an SMTP server using the option 'skip_mta'. Note that in most cases is recommended to
+use an SMTP outbound server as the MTA, but if you know what you're doing you can use skip_mta and then alerta-mailer
+will resolve the proper destination MX DNS record for each address and attempt to deliver the email directly. Some
+email systems may detect certain email patterns to black-list you, such as sending email using a hostname such as
+'localhost'. You may need to set the 'mail_localhost' option or set a proper FQDN in your server to avoid this.
+
+You can also use IP-authentication in your own SMTP server (by only white-listing the alerta server IP), in such
+cases you should not set the 'smtp_password' option to skip authentication altogether.
 
 Application-specific passwords
 https://support.google.com/accounts/answer/185833?hl=en


### PR DESCRIPTION
The new option skip_mta can be used to send emails directly without
using an intermediary MTA. Note this might get you black-listed and
it doesn't work in many other cases, however is quite useful to not
require any kind of email account to send notifications.

Anyone using this option may also want to use also the new
option mail_localhost to avoid getting black-listed by software like
spamhaus/cbl that might block hosts sending email using 'localhost'
as the host during the smtp EHLO command.

A few additional fixes in this commit:

* Add smtp_starttls option to enable/disable the STARTTLS extension.
  This is enabled by default for security and backwards compatibility.

* Provide the endpoint and key options to ApiClient(), they were being
  ignored before.

* Use adequate data types for the OPTIONS elements. The data type
  is detected used a new DEFAULT_OPTIONS hash and then using the
  proper config getter function.