### PR TITLE
Add missing global declaration

### DIFF
--- a/integrations/mailer/mailer.py
+++ b/integrations/mailer/mailer.py
@@ -243,6 +243,8 @@ class MailSender(threading.Thread):
 
 
 def main():
+    global OPTIONS
+
     CONFIG_SECTION = 'alerta-mailer'
     config_file = os.environ.get('ALERTA_CONF_FILE') or DEFAULT_OPTIONS['config_file']
 


### PR DESCRIPTION
Sorry, I missed this when making a simple last minute change to my MTA pull request and I didn't install that one change when testing so turns out that small change broke the mailer startup. This fixes the startup issue.