### PR TITLE
Make the mailer template location and the mail subject configurable

### DIFF
--- a/integrations/mailer/README.md
+++ b/integrations/mailer/README.md
@@ -74,8 +74,3 @@ Dependencies
 ------------
 
 The Alerta server *MUST* have the AMQP plugin enabled and configured. See [default settings](https://github.com/guardian/alerta/blob/master/alerta/settings.py#L57)
-
-TODO
-----
-
- - [ ] make the template location configurable.


### PR DESCRIPTION
The template location can now be specified using the configuration option 'mail_template'

The subject can be specified using a jinja string/template using 'mail_subject', defaulting to the same string as before.

I added a small fix on the logging configuration that strictly speaking has nothing to do with this PR but seemed like overkill to make another PR for a simple one-liner. If you prefer a separate PR just let me know.