### PR TITLE
Add support for multiple config files, and refactor of the notifications

### DIFF
--- a/integrations/mailer/README.md
+++ b/integrations/mailer/README.md
@@ -52,19 +52,17 @@ skip_mta = False
 email_type = text
 ```
 
-Notifications by different groups of server can be enabled using the section
-called ``[notifications]`` see the example above.
+Notifications to other emails according regexp criteria can be enabled,
+creating a section and calling them with the ``notification`` prefix see the example 
+above.
 
 ```
-[notifications]
-rules = notification1, notification2
-
-[notification1]
+[notification:foo]
 field = alert.resource
 regex = db-\w+
 contacts = dba@lists.mycompany.com, dev@lists.mycompany.com
 
-[notification2]
+[notification:bar]
 field = alert.resource
 regex = web-\w+
 contacts = dev@lists.mycompany.com 
@@ -89,6 +87,15 @@ The variable email_type can have 2 possible values:
 - html: for just html emails, will fallback to text for text clients (mutt,
   etc) 
 - text: for just plain text emails
+
+Multiple files config support
+-----------------------------
+
+Multiple configs files are supported for alerta-mailer you just need to create
+a directory with the name of the config file with the .d suffix, i.e: (assuming
+you have a config file called ``mailer.conf`` on ``/etc/alerta/`` you will need
+to create the directory ``mailer.conf.d`` at the same level of your config file
+(mailer.conf in this example), and place all your configs there.
 
 Deployment
 ----------

--- a/integrations/mailer/setup.py
+++ b/integrations/mailer/setup.py
@@ -2,7 +2,7 @@
 
 import setuptools
 
-version = '3.2.0'
+version = '3.3.0'
 
 setuptools.setup(
     name="alerta-mailer",
@@ -13,7 +13,7 @@ setuptools.setup(
     author='Nick Satterly',
     author_email='nick.satterly@theguardian.com',
     py_modules=['mailer'],
-    data_files=[('.', ['email.tmpl'])],
+    data_files=[('.', ['email.tmpl', 'email.html.tmpl'])],
     install_requires=[
         'alerta',
         'kombu',


### PR DESCRIPTION
One of these changes break compatibility with the 3.2.0 version (last week released), since is not using anymore the notifications section, instead now is getting all the sections named "notification:" and iterate over them. 