### PR TITLE
Pagerduty: automatically resolve incidents when alert severity is "ok" 

### DIFF
--- a/plugins/pagerduty/pagerduty.py
+++ b/plugins/pagerduty/pagerduty.py
@@ -28,10 +28,15 @@ class TriggerEvent(PluginBase):
             ','.join(alert.service), alert.resource, alert.event
         )
 
+        if alert.severity == 'ok':
+            event_type = "resolve"
+        else:
+            event_type = "trigger"
+
         payload = {
             "service_key": PAGERDUTY_SERVICE_KEY,
             "incident_key": alert.id,
-            "event_type": "trigger",
+            "event_type": event_type,
             "description": message,
             "client": "alerta",
             "client_url": '%s/#/alert/%s' % (DASHBOARD_URL, alert.id),


### PR DESCRIPTION
This PR allows the pagerduty plugin to resolve incidents automatically once an alert transitions into the "ok" state.

Based on a "resolve" event. More info in here: https://developer.pagerduty.com/documentation/integration/events/resolve