### PR TITLE
Changing eval for getattr because security reasons, spotted by @jmesquita

### DIFF
--- a/integrations/mailer/README.md
+++ b/integrations/mailer/README.md
@@ -58,12 +58,12 @@ above.
 
 ```
 [notification:foo]
-field = alert.resource
+field = resource
 regex = db-\w+
 contacts = dba@lists.mycompany.com, dev@lists.mycompany.com
 
 [notification:bar]
-field = alert.resource
+field = resource
 regex = web-\w+
 contacts = dev@lists.mycompany.com 
 ```

--- a/integrations/mailer/mailer.py
+++ b/integrations/mailer/mailer.py
@@ -197,8 +197,10 @@ class MailSender(threading.Thread):
             LOG.debug('Checking %d group rules' % len(OPTIONS['group_rules']))
             for rules in OPTIONS['group_rules']:
                 LOG.debug('Matching regex %s to %s (%s)' % (rules['regex'],
-                         rules['field'], eval(rules['field'])))
-                if re.match(rules['regex'], eval(rules['field'])):
+                          rules['field'],
+                          getattr(alert, rules['field'], None)))
+                if re.match(rules['regex'],
+                            getattr(alert, rules['field'], None)):
                     LOG.debug('Regex matched')
                     # Add up any new contacts
                     new_contacts = [x.strip() for x in rules['contacts'].split(',')

--- a/integrations/mailer/setup.py
+++ b/integrations/mailer/setup.py
@@ -2,7 +2,7 @@
 
 import setuptools
 
-version = '3.3.1'
+version = '3.3.2'
 
 setuptools.setup(
     name="alerta-mailer",


### PR DESCRIPTION
@jmesquita pointed a concern that I admit with lot of shame that I've used eval and not getattr I am sorry for this, the PR is attached