### PR TITLE
Move email rules to more flexible JSON format

### DIFF
--- a/integrations/mailer/README.md
+++ b/integrations/mailer/README.md
@@ -53,24 +53,33 @@ email_type = text
 ```
 
 Notifications to other emails according regexp criteria can be enabled,
-creating a section and calling them with the ``notification`` prefix see the example 
-above.
+creating a JSON formatted file under ```alerta.rules.d/``` with the following format:
 
 ```
-[notification:foo]
-field = resource
-regex = db-\w+
-contacts = dba@lists.mycompany.com, dev@lists.mycompany.com
-
-[notification:bar]
-field = resource
-regex = web-\w+
-contacts = dev@lists.mycompany.com 
+[
+    {
+        "name": "foo",
+        "fields": [
+            {"field": "resource", "regex": "db-\w+"}
+        ],
+        "contacts": ["dba@lists.mycompany.com", "dev@lists.mycompany.com"]
+    },
+    {
+        "name": "bar",
+        "fields": [
+            {"field": "resource", "regex": "web-\w+"}
+        ],
+        "contacts": ["dev@lists.mycompany.com"]
+    }
+]
 ```
 
-field is a reference to the alert object, regex is a valid python regexp and
-contacts are a list (comma separated) of mails who will receive an e-mail if
+``field``` is a reference to the alert object, regex is a valid python regexp and
+contacts are a list of mails who will receive an e-mail if
 the regular expression matches.
+
+Multiple ```field``` dictionary can be supplied and all ```regex``` must match for
+the email to be sent.
 
 Environment Variables
 ---------------------
@@ -97,6 +106,9 @@ you have a config file called ``mailer.conf`` on ``/etc/alerta/`` you will need
 to create the directory ``mailer.conf.d`` at the same level of your config file
 (mailer.conf in this example), and place all your configs there.
 
+Multiple email rules files can be supplied as well and rules are going to be applied
+top-down as they appear on the filesystem and on the files themselves.
+
 Deployment
 ----------
 
@@ -107,3 +119,12 @@ Dependencies
 ------------
 
 The Alerta server *MUST* have the AMQP plugin enabled and configured. See [default settings](https://github.com/guardian/alerta/blob/master/alerta/settings.py#L57)
+
+Testing
+-------
+
+Running unit-tests should required nothing else but running:
+
+```
+python setup.py test
+```

--- a/integrations/mailer/setup.cfg
+++ b/integrations/mailer/setup.cfg
@@ -1,0 +1,2 @@
+[aliases]
+test=pytest

--- a/integrations/mailer/setup.py
+++ b/integrations/mailer/setup.py
@@ -2,7 +2,7 @@
 
 import setuptools
 
-version = '3.3.2'
+version = '3.4.0'
 
 setuptools.setup(
     name="alerta-mailer",
@@ -14,6 +14,8 @@ setuptools.setup(
     author_email='nick.satterly@theguardian.com',
     py_modules=['mailer'],
     data_files=[('.', ['email.tmpl', 'email.html.tmpl'])],
+    setup_requires=['pytest-runner'],
+    tests_require=['pytest', 'mock', 'pytest-capturelog'],
     install_requires=[
         'alerta',
         'kombu',

--- a/integrations/mailer/tests/test_rules.py
+++ b/integrations/mailer/tests/test_rules.py
@@ -1,0 +1,131 @@
+'''
+Unit test definitions for all rules
+'''
+import pytest
+import mailer
+from mock import MagicMock, patch, DEFAULT
+
+
+def test_rules_dont_exist():
+    '''
+    Test the rules file is read
+    '''
+    with patch('mailer.os') as system_os:
+        system_os.path.exists.return_value = False
+        res = mailer.parse_group_rules('config_file')
+        system_os.path.exists.called_once_with('confile_file')
+        assert res is None
+
+
+def test_rules_parsing():
+    '''
+    Test the rules file is properly read
+    '''
+    with patch.multiple(mailer, os=DEFAULT, open=DEFAULT,
+                        json=DEFAULT, validate_rules=DEFAULT) as mocks:
+        mocks['os'].path.exists.return_value = True
+        mocks['os'].walk().__iter__\
+            .return_value = [(None, None, 'cantopen.json'),
+                             (None, None, 'invalid.json'),
+                             (None, None, 'valid.json')]
+        invalid_file = MagicMock()
+        valid_file = MagicMock()
+        mocks['open'].side_effect = [IOError, invalid_file, valid_file]
+        doc = [{'notify': {'fields': []}}]
+        mocks['json'].load.side_effect = [TypeError, doc]
+        mocks['validate_rules'].return_value = doc
+        res = mailer.parse_group_rules('config_file')
+
+        # Assert that we checked for folder existence
+        mocks['os'].path.exists.called_once_with('confile_file')
+
+        # Check that validation was called for valid file
+        mocks['validate_rules'].assert_called_once_with(doc)
+        assert mocks['validate_rules'].call_count == 1
+
+        # Assert that we tried to open all 3 files
+        assert mocks['open'].call_count == 3
+        # Assert that we tried to load 2 files only
+        assert mocks['json'].load.call_count == 2
+        # Assert that we have proper return value
+        assert res == doc
+
+
+TESTDOCS = [
+    ('', False),
+    ('String', False),
+    ({}, False),
+    ([], True),
+    ([
+        {"name": "invalid_no_fields"}
+    ], False),
+    ([
+        {"name": "invalid_empty_fields",
+         "fields": []}
+    ], False),
+    ([
+        {"name": "invalid_no_contacts",
+         "fields": [{"field": "resource", "regex": r"\d{4}"}]}
+    ], False),
+    ([
+        {"name": "invalid_no_fields_field",
+         "fields": [{"regex": r"\d{4}"}]}
+    ], False),
+    ([
+        {"name": "invalid_no_fields_not_list",
+         "fields": {"regex": r"\d{4}"}}
+    ], False),
+    ([
+        {"name": "invalid_no_fields_regex",
+         "fields": [{"field": "test"}]}
+    ], False),
+]
+
+
+@pytest.mark.parametrize('doc, is_valid', TESTDOCS)
+def test_rules_validation(doc, is_valid):
+    '''
+    Test rule validation
+    '''
+    res = mailer.validate_rules(doc)
+    if is_valid:
+        assert res is not None
+    else:
+        assert res is None or res == []
+
+
+RULES_DATA = [
+    [],
+    [{
+        "name": "Test1",
+        "fields": [{"field": "resource", "regex": r"\d{4}"}],
+        "contacts": ["test@example.com"]
+    }]
+]
+
+
+@pytest.mark.parametrize('rules', RULES_DATA)
+def test_rules_evaluation(rules):
+    '''
+    Test that rules are properly evaluated
+    '''
+    with patch.dict(mailer.OPTIONS, mailer.DEFAULT_OPTIONS):
+        contacts = MagicMock()
+        mailer.OPTIONS['mail_to'] = contacts
+        print contacts, list(contacts)
+        mailer.OPTIONS['group_rules'] = rules
+        mail_sender = mailer.MailSender()
+        with patch.object(mail_sender, '_send_email_message') as _sem:
+            with patch.object(mailer, 're') as regex:
+                alert = MagicMock()
+                mail_sender.send_email(alert)
+                assert _sem.call_count == 1
+                call_count = 0
+                for rule in rules:
+                    contacts.extend.assert_called_once_with(rule['contacts'])
+                    call_count += len(rule['fields'])
+                    for fields in rule['fields']:
+                        regex.match.assert_called_with(
+                            fields['regex'],
+                            getattr(alert, fields['field']))
+                assert regex.match.call_count == call_count

--- a/integrations/mailer/tests/test_rules.py
+++ b/integrations/mailer/tests/test_rules.py
@@ -25,9 +25,8 @@ def test_rules_parsing():
                         json=DEFAULT, validate_rules=DEFAULT) as mocks:
         mocks['os'].path.exists.return_value = True
         mocks['os'].walk().__iter__\
-            .return_value = [(None, None, 'cantopen.json'),
-                             (None, None, 'invalid.json'),
-                             (None, None, 'valid.json')]
+            .return_value = [('/', None,
+                              ['cantopen.json', 'invalid.json', 'valid.json'])]
         invalid_file = MagicMock()
         valid_file = MagicMock()
         mocks['open'].side_effect = [IOError, invalid_file, valid_file]
@@ -57,27 +56,32 @@ TESTDOCS = [
     ({}, False),
     ([], True),
     ([
-        {"name": "invalid_no_fields"}
+        {"name": "invalid_no_fields",
+         "contacts": []}
     ], False),
     ([
         {"name": "invalid_empty_fields",
-         "fields": []}
+         "fields": [],
+         "contacts": []}
     ], False),
     ([
         {"name": "invalid_no_contacts",
          "fields": [{"field": "resource", "regex": r"\d{4}"}]}
     ], False),
     ([
-        {"name": "invalid_no_fields_field",
-         "fields": [{"regex": r"\d{4}"}]}
+        {"name": "invalid_no_field_on_fields",
+         "fields": [{"regex": r"\d{4}"}],
+         "contacts": []}
     ], False),
     ([
-        {"name": "invalid_no_fields_not_list",
-         "fields": {"regex": r"\d{4}"}}
+        {"name": "invalid_fields_not_list",
+         "fields": {"regex": r"\d{4}"},
+         "contacts": []}
     ], False),
     ([
         {"name": "invalid_no_fields_regex",
-         "fields": [{"field": "test"}]}
+         "fields": [{"field": "test"}],
+         "contacts": []}
     ], False),
 ]
 


### PR DESCRIPTION
* alerta-mailer now has unit tests using py.test
* rules should be ported to new JSON format

The reasoning behind this is to make use of a more machine friendly format to email rules without compromising human readability. Using a nested format like JSON allows us to provide more flexibility to the configuration as well.

Another PR based on this PR is coming to extend functionality but I wanted to split it in two parts so we can have better review process on the modifications.