### PR TITLE
Fix empty service field when posting to slack

### DIFF
--- a/plugins/slack/setup.py
+++ b/plugins/slack/setup.py
@@ -2,7 +2,7 @@
 
 import setuptools
 
-version = '0.1.3'
+version = '0.1.4'
 
 setuptools.setup(
     name="alerta-slack",

--- a/plugins/slack/slack.py
+++ b/plugins/slack/slack.py
@@ -66,7 +66,7 @@ class ServiceIntegration(PluginBase):
                         {"title": "Status", "value": alert.status.capitalize(), "short": True},
                         {"title": "Environment", "value": alert.environment, "short": True},
                         {"title": "Resource", "value": alert.resource, "short": True},
-                        {"title": "Service", "value": alert.service, "short": True}
+                        {"title": "Services", "value": ", ".join(alert.service), "short": True}
                     ]
                 }]
             }


### PR DESCRIPTION
Service field in a Slack message is empty:
![screenshot from 2016-05-27 13 54 06](https://cloud.githubusercontent.com/assets/4865412/15600260/17f43388-2413-11e6-9474-602b3eae397c.png)

While the json data sent to Alerta actually includes a service attribute:

![screenshot from 2016-05-27 13 53 35](https://cloud.githubusercontent.com/assets/4865412/15600278/31262654-2413-11e6-8b56-356003ce4b0d.png)

According to the document (http://docs.alerta.io/en/latest/api/reference.html#send-an-alert), the "service" attribute is sent to Alerta in an array of string:
```
{
  "resource": "web01",
  "event": "HttpServerError",
  "environment": "Production",
  "severity": "major",
  "status": "open",
  "correlate": [
    "HttpServerError",
    "HttpServerOK"
  ],
  "service": [
    "example.com"
  ],
  "group": "Web",
  "value": "Bad Gateway (501)",
  "text": "The site is down.",
  "tags": [
    "london"
  ],
  "attributes": {
    "company": "ACME Corp"
  },
  "origin": "curl",
  "type": "webAlert"
}
```
So it makes sense to join these strings with `", "` for displaying message purpose.