### PR TITLE
Set useful logger name for plugins

### DIFF
--- a/plugins/amqp/alerta_amqp.py
+++ b/plugins/amqp/alerta_amqp.py
@@ -1,4 +1,5 @@
 import os
+import logging
 
 from kombu import BrokerConnection, Exchange, Producer
 from kombu.utils.debug import setup_logging
@@ -6,7 +7,7 @@ from kombu.utils.debug import setup_logging
 from alerta.app import app
 from alerta.plugins import PluginBase
 
-LOG = app.logger
+LOG = logging.getLogger('alerta.plugins.amqp')
 
 DEFAULT_AMQP_URL = 'mongodb://localhost:27017/kombu'
 DEFAULT_AMQP_TOPIC = 'notify'

--- a/plugins/amqp/setup.py
+++ b/plugins/amqp/setup.py
@@ -1,7 +1,7 @@
 
 from setuptools import setup, find_packages
 
-version = '0.3.0'
+version = '0.3.1'
 
 setup(
     name="alerta-amqp",

--- a/plugins/enhance/alerta_enhance.py
+++ b/plugins/enhance/alerta_enhance.py
@@ -1,10 +1,16 @@
+import logging
 
 from alerta.plugins import PluginBase
+
+LOG = logging.getLogger('alerta.plugins.enhance')
 
 
 class EnhanceAlert(PluginBase):
 
     def pre_receive(self, alert):
+
+        LOG.info("Enhancing alert...")
+
         if 'TPS reports' in alert.text:
             alert.attributes['customer'] = 'Initech'
         elif 'nexus' in alert.text:

--- a/plugins/enhance/setup.py
+++ b/plugins/enhance/setup.py
@@ -1,7 +1,7 @@
 
 from setuptools import setup, find_packages
 
-version = '0.3.0'
+version = '0.3.1'
 
 setup(
     name="alerta-enhance",

--- a/plugins/geoip/alerta_geoip.py
+++ b/plugins/geoip/alerta_geoip.py
@@ -1,11 +1,12 @@
 
 import os
 import requests
+import logging
 
 from alerta.app import app
 from alerta.plugins import PluginBase
 
-LOG = app.logger
+LOG = logging.getLogger('alerta.plugins.geoip')
 
 GEOIP_URL = os.environ.get('GEOIP_URL') or app.config.get('GEOIP_URL', 'http://freegeoip.net/json')
 
@@ -17,12 +18,14 @@ class GeoLocation(PluginBase):
         if 'ip' in alert.attributes:
             url = '%s/%s' % (GEOIP_URL, alert.attributes['ip'])
         else:
+            LOG.warning("IP address must be included as an alert attribute.")
             raise RuntimeWarning("IP address must be included as an alert attribute.")
 
         r = requests.get(url, headers={'Content-type': 'application/json'}, timeout=2)
         try:
             alert.attributes.update(r.json())
         except Exception as e:
+            LOG.error("GeoIP lookup failed: %s" % str(e))
             raise RuntimeError("GeoIP lookup failed: %s" % str(e))
 
         return alert

--- a/plugins/geoip/setup.py
+++ b/plugins/geoip/setup.py
@@ -1,7 +1,7 @@
 
 from setuptools import setup, find_packages
 
-version = '0.3.0'
+version = '0.3.1'
 
 setup(
     name="alerta-geoip",

--- a/plugins/hipchat/alerta_hipchat.py
+++ b/plugins/hipchat/alerta_hipchat.py
@@ -2,11 +2,12 @@
 import os
 import json
 import requests
+import logging
 
 from alerta.app import app
 from alerta.plugins import PluginBase
 
-LOG = app.logger
+LOG = logging.getLogger('alerta.plugins.hipchat')
 
 HIPCHAT_URL = 'https://api.hipchat.com/v2'
 HIPCHAT_ROOM = os.environ.get('HIPCHAT_ROOM') or app.config['HIPCHAT_ROOM']  # Room Name or Room API ID

--- a/plugins/hipchat/setup.py
+++ b/plugins/hipchat/setup.py
@@ -1,7 +1,7 @@
 
 from setuptools import setup, find_packages
 
-version = '0.3.0'
+version = '0.3.1'
 
 setup(
     name="alerta-hipchat",

--- a/plugins/influxdb/alerta_influxdb.py
+++ b/plugins/influxdb/alerta_influxdb.py
@@ -2,11 +2,12 @@
 import os
 import json
 import requests
+import logging
 
 from alerta.app import app
 from alerta.plugins import PluginBase
 
-LOG = app.logger
+LOG = logging.getLogger('alerta.plugins.influxdb')
 
 INFLUXDB_URL = os.environ.get('INFLUXDB_URL') or app.config['INFLUXDB_URL']
 INFLUXDB_USER = os.environ.get('INFLUXDB_USER') or app.config['INFLUXDB_USER']

--- a/plugins/influxdb/setup.py
+++ b/plugins/influxdb/setup.py
@@ -1,7 +1,7 @@
 
 from setuptools import setup, find_packages
 
-version = '0.3.0'
+version = '0.3.1'
 
 setup(
     name="alerta-influxdb",

--- a/plugins/logstash/alerta_logstash.py
+++ b/plugins/logstash/alerta_logstash.py
@@ -1,10 +1,12 @@
 import os
 import socket
+import logging
 
 from alerta.app import app
 from alerta.plugins import PluginBase
 
-LOG = app.logger
+
+LOG = logging.getLogger('alerta.plugins.logstash')
 
 DEFAULT_LOGSTASH_HOST = 'localhost'
 DEFAULT_LOGSTASH_PORT = 6379

--- a/plugins/logstash/setup.py
+++ b/plugins/logstash/setup.py
@@ -1,7 +1,7 @@
 
 from setuptools import setup, find_packages
 
-version = '0.3.0'
+version = '0.3.1'
 
 setup(
     name="alerta-logstash",

--- a/plugins/normalise/alerta_normalise.py
+++ b/plugins/normalise/alerta_normalise.py
@@ -1,11 +1,18 @@
+import logging
 
 from alerta.plugins import PluginBase
+
+LOG = logging.getLogger('alerta.plugins.normalise')
 
 
 class NormaliseAlert(PluginBase):
 
     def pre_receive(self, alert):
+
+        LOG.info("Normalising alert...")
+
         alert.text = '%s: %s' % (alert.severity.upper(), alert.text)
+
         return alert
 
     def post_receive(self, alert):

--- a/plugins/normalise/setup.py
+++ b/plugins/normalise/setup.py
@@ -1,7 +1,7 @@
 
 from setuptools import setup, find_packages
 
-version = '0.3.0'
+version = '0.3.1'
 
 setup(
     name="alerta-normalise",

--- a/plugins/pagerduty/alerta_pagerduty.py
+++ b/plugins/pagerduty/alerta_pagerduty.py
@@ -1,12 +1,12 @@
 
 import os
-import json
 import requests
+import logging
 
 from alerta.app import app
 from alerta.plugins import PluginBase
 
-LOG = app.logger
+LOG = logging.getLogger('alerta.plugins.pagerduty')
 
 PAGERDUTY_EVENTS_URL = 'https://events.pagerduty.com/generic/2010-04-15/create_event.json'
 PAGERDUTY_SERVICE_KEY = os.environ.get('PAGERDUTY_SERVICE_KEY') or app.config['PAGERDUTY_SERVICE_KEY']

--- a/plugins/pagerduty/setup.py
+++ b/plugins/pagerduty/setup.py
@@ -1,7 +1,7 @@
 
 from setuptools import setup, find_packages
 
-version = '0.3.0'
+version = '0.3.1'
 
 setup(
     name="alerta-pagerduty",

--- a/plugins/prometheus/alerta_prometheus.py
+++ b/plugins/prometheus/alerta_prometheus.py
@@ -1,12 +1,12 @@
 
 import datetime
 import requests
+import logging
 
 from alerta.app import app
 from alerta.plugins import PluginBase
 
-LOG = app.logger
-
+LOG = logging.getLogger('alerta.plugins.prometheus')
 
 ALERTMANAGER_API_URL = 'http://localhost:9093'
 ALERTMANAGER_API_KEY = ''  # not used

--- a/plugins/prometheus/setup.py
+++ b/plugins/prometheus/setup.py
@@ -1,7 +1,7 @@
 
 from setuptools import setup, find_packages
 
-version = '0.3.0'
+version = '0.3.1'
 
 setup(
     name="alerta-prometheus",

--- a/plugins/pushover/alerta_pushover.py
+++ b/plugins/pushover/alerta_pushover.py
@@ -1,11 +1,12 @@
 
 import os
 import requests
+import logging
 
 from alerta.app import app
 from alerta.plugins import PluginBase
 
-LOG = app.logger
+LOG = logging.getLogger('alerta.plugins.pushover')
 
 PUSHOVER_URL = 'https://api.pushover.net/1/messages.json'
 

--- a/plugins/pushover/setup.py
+++ b/plugins/pushover/setup.py
@@ -1,7 +1,7 @@
 
 from setuptools import setup, find_packages
 
-version = '0.3.0'
+version = '0.3.1'
 
 setup(
     name="alerta-pushover",

--- a/plugins/slack/setup.py
+++ b/plugins/slack/setup.py
@@ -1,7 +1,7 @@
 
 from setuptools import setup, find_packages
 
-version = '0.3.0'
+version = '0.3.1'
 
 setup(
     name="alerta-slack",

--- a/plugins/slack/slack.py
+++ b/plugins/slack/slack.py
@@ -2,11 +2,12 @@
 import os
 import json
 import requests
+import logging
 
 from alerta.app import app
 from alerta.plugins import PluginBase
 
-LOG = app.logger
+LOG = logging.getLogger('alerta.plugins.slack')
 
 SLACK_WEBHOOK_URL = os.environ.get('SLACK_WEBHOOK_URL') or app.config['SLACK_WEBHOOK_URL']
 SLACK_ATTACHMENTS = True if os.environ.get('SLACK_ATTACHMENTS', 'False') == 'True' else app.config.get('SLACK_ATTACHMENTS', False)

--- a/plugins/sns/alerta_sns.py
+++ b/plugins/sns/alerta_sns.py
@@ -1,4 +1,5 @@
 import os
+import logging
 
 import boto.sns
 import boto.exception
@@ -6,7 +7,7 @@ import boto.exception
 from alerta.app import app
 from alerta.plugins import PluginBase
 
-LOG = app.logger
+LOG = logging.getLogger('alerta.plugins.sns')
 
 DEFAULT_AWS_REGION = 'eu-west-1'
 DEFAULT_AWS_SNS_TOPIC = 'notify'

--- a/plugins/sns/setup.py
+++ b/plugins/sns/setup.py
@@ -1,7 +1,7 @@
 
 from setuptools import setup, find_packages
 
-version = '0.3.0'
+version = '0.3.1'
 
 setup(
     name="alerta-sns",

--- a/plugins/syslog/alerta_logger.py
+++ b/plugins/syslog/alerta_logger.py
@@ -8,15 +8,18 @@ from logging.handlers import SysLogHandler
 from alerta.app import app
 from alerta.plugins import PluginBase
 
+LOG = logging.getLogger('alerta.plugins.logger')
+
 LOGGER_SYSLOG_FORMAT = os.environ.get('LOGGER_SYSLOG_FORMAT') or app.config.get('SYSLOG_FORMAT','%(name)s[%(process)d]: %(levelname)s - %(message)s')
 LOGGER_SYSLOG_DATE_FORMAT = os.environ.get('LOGGER_SYSLOG_DATE_FORMAT') or app.config.get('SYSLOG_DATE_FORMAT', '%Y-%m-%d %H:%M:%S')
 LOGGER_SYSLOG_FACILITY = os.environ.get('LOGGER_SYSLOG_FACILITY') or app.config.get('SYSLOG_FACILITY', 'local7')
+
 
 class Syslog(PluginBase):
 
     def __init__(self, name=None):
 
-        self.logger = logging.getLogger('alerta')
+        self.logger = logging.getLogger(name)
 
         if sys.platform == "darwin":
             socket = '/var/run/syslog'
@@ -25,8 +28,7 @@ class Syslog(PluginBase):
         facility = LOGGER_SYSLOG_FACILITY
 
         syslog = SysLogHandler(address=socket, facility=facility)
-        formatter = logging.Formatter(fmt=LOGGER_SYSLOG_FORMAT, datefmt=LOGGER_SYSLOG_DATE_FORMAT)
-        syslog.setFormatter(formatter)
+        syslog.setFormatter(logging.Formatter(fmt=LOGGER_SYSLOG_FORMAT, datefmt=LOGGER_SYSLOG_DATE_FORMAT))
         self.logger.addHandler(syslog)
 
         super(Syslog, self).__init__(name)

--- a/plugins/syslog/setup.py
+++ b/plugins/syslog/setup.py
@@ -1,7 +1,7 @@
 
 from setuptools import setup, find_packages
 
-version = '0.3.0'
+version = '0.3.1'
 
 setup(
     name="alerta-logger",

--- a/plugins/twilio/alerta_twilio_sms.py
+++ b/plugins/twilio/alerta_twilio_sms.py
@@ -1,12 +1,13 @@
 
 import os
+import logging
 
 from twilio.rest import TwilioRestClient
 
 from alerta.app import app
 from alerta.plugins import PluginBase
 
-LOG = app.logger
+LOG = logging.getLogger('alerta.plugins.twilio')
 
 TWILIO_ACCOUNT_SID = os.environ.get('TWILIO_ACCOUNT_SID') or app.config['TWILIO_ACCOUNT_SID']
 TWILIO_AUTH_TOKEN = os.environ.get('TWILIO_AUTH_TOKEN') or app.config['TWILIO_AUTH_TOKEN']

--- a/plugins/twilio/setup.py
+++ b/plugins/twilio/setup.py
@@ -1,7 +1,7 @@
 
 from setuptools import setup, find_packages
 
-version = '0.3.0'
+version = '0.3.1'
 
 setup(
     name="alerta-twilio",


### PR DESCRIPTION
Example
```
2016-09-15 10:13:43,960 - alerta.plugins.geoip[11818]: CRITICAL - this is from GEO IP !!!!!! [in build/bdist.macosx-10.9-x86_64/egg/alerta_geoip.py:18]

```