### PR TITLE
Fix codec error if the text includes non-ascii charators

### DIFF
--- a/integrations/mailer/mailer.py
+++ b/integrations/mailer/mailer.py
@@ -10,6 +10,7 @@ import socket
 import sys
 import threading
 import time
+from email.header import Header
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 
@@ -271,10 +272,10 @@ class MailSender(threading.Thread):
             html = None
 
         msg = MIMEMultipart('alternative')
-        msg['Subject'] = subject
+        msg['Subject'] = Header(subject, 'utf-8').encode()
         msg['From'] = OPTIONS['mail_from']
         msg['To'] = ", ".join(contacts)
-        msg.preamble = subject
+        msg.preamble = msg['Subject']
 
         # by default we are going to assume that the email is going to be text
         msg_text = MIMEText(text, 'plain', 'utf-8')


### PR DESCRIPTION
In order to be compatible with multiple languages, the text(the subject included) in the message body should be encoded in utf-8 to avoid `UnicodeEncodeError`when we call msg.as_string(). It seems that the subject field in line 279 misses it, I fixed it with `Header` wrapper.