### PR TITLE
Delete silences in Prometheus Alertmanager

### DIFF
--- a/plugins/prometheus/README.md
+++ b/plugins/prometheus/README.md
@@ -1,1 +1,24 @@
+Prometheus Alertmanager Plugin
+==============================
+
 Silence alerts in Alertmanager when acking alerts in the Alerta console
+and delete silences if alerts are manually opened.
+
+Installation
+------------
+
+    $ python setup.py install
+
+
+Configuration
+-------------
+
+```
+ALERTMANAGER_API_URL = 'https://prom.example.com:9093'  # default=http://localhost:9093
+ALERTMANAGER_SILENCE_DAYS = n  # default=1
+```
+
+References
+----------
+
+https://prometheus.io/docs/alerting/alertmanager/#silences

--- a/plugins/prometheus/alerta_prometheus.py
+++ b/plugins/prometheus/alerta_prometheus.py
@@ -1,16 +1,18 @@
 
+import os
 import datetime
 import requests
 import logging
 
 from alerta.app import app
+from alerta.app import db
 from alerta.plugins import PluginBase
 
 LOG = logging.getLogger('alerta.plugins.prometheus')
 
-ALERTMANAGER_API_URL = 'http://localhost:9093'
-ALERTMANAGER_API_KEY = ''  # not used
-ALERTMANAGER_SILENCE_DAYS = 1
+ALERTMANAGER_API_URL = os.environ.get('ALERTMANAGER_API_URL') or app.config.get('ALERTMANAGER_API_URL', 'http://localhost:9093')
+ALERTMANAGER_API_KEY = os.environ.get('ALERTMANAGER_API_KEY') or app.config.get('ALERTMANAGER_API_KEY', '')  # not used
+ALERTMANAGER_SILENCE_DAYS = os.environ.get('ALERTMANAGER_SILENCE_DAYS') or app.config.get('ALERTMANAGER_SILENCE_DAYS', 1)
 
 
 class AlertmanagerSilence(PluginBase):
@@ -22,6 +24,7 @@ class AlertmanagerSilence(PluginBase):
         return
 
     def status_change(self, alert, status, text):
+
         if alert.event_type != 'prometheusAlert':
             return
 
@@ -29,9 +32,7 @@ class AlertmanagerSilence(PluginBase):
             return
 
         if status == 'ack':
-
-            url = ALERTMANAGER_API_URL + '/api/v1/silences'
-
+            LOG.debug('Alertmanager: Add silence for alertname=%s instance=%s', alert.event, alert.resource)
             data = {
                 "matchers": [
                     {
@@ -49,12 +50,36 @@ class AlertmanagerSilence(PluginBase):
                 "createdBy": "alerta",
                 "comment": text if text != '' else "silenced by alerta"
             }
-            LOG.debug('Alertmanager payload: %s', data)
 
-            LOG.debug('Alertmanager sending silence request to %s', url)
+            url = ALERTMANAGER_API_URL + '/api/v1/silences'
             try:
                 r = requests.post(url, json=data, timeout=2)
             except Exception as e:
-                raise RuntimeError("Alertmanager connection error: %s", e)
+                raise RuntimeError("Alertmanager: ERROR - %s", e)
+            LOG.debug('Alertmanager: %s - %s', r.status_code, r.text)
 
-            LOG.debug('Alertmanager response: %s - %s', r.status_code, r.text)
+            # example r={"status":"success","data":{"silenceId":8}}
+            try:
+                silenceId = r.json()['data']['silenceId']
+                db.update_attributes(alert.id, {'silenceId': silenceId})
+            except Exception as e:
+                raise RuntimeError("Alertmanager: ERROR - %s", e)
+            LOG.debug('Alertmanager: Added silenceId %s to attributes', silenceId)
+
+        elif status == 'open':
+            LOG.debug('Alertmanager: Remove silence for alertname=%s instance=%s', alert.event, alert.resource)
+
+            silenceId = alert.attributes.get('silenceId', None)
+            if silenceId:
+                url = ALERTMANAGER_API_URL + '/api/v1/silence/%s' % silenceId
+                try:
+                    r = requests.delete(url, timeout=2)
+                except Exception as e:
+                    raise RuntimeError("Alertmanager: ERROR - %s", e)
+                LOG.debug('Alertmanager: %s - %s', r.status_code, r.text)
+
+                try:
+                    db.update_attributes(alert.id, {'silenceId': None})
+                except Exception as e:
+                    raise RuntimeError("Alertmanager: ERROR - %s", e)
+                LOG.debug('Alertmanager: Removed silenceId %s from attributes', silenceId)

--- a/plugins/prometheus/setup.py
+++ b/plugins/prometheus/setup.py
@@ -1,7 +1,7 @@
 
 from setuptools import setup, find_packages
 
-version = '0.3.1'
+version = '0.3.2'
 
 setup(
     name="alerta-prometheus",


### PR DESCRIPTION
Remove silences created by Alerta from Prometheus Alertmanager when an alert is manually set to `open`. Note that this takes advantage of an undocumented API.

Fixes guardian/alerta#278