### PR TITLE
record alert severity in influxdb as a tag

### DIFF
--- a/plugins/influxdb/alerta_influxdb.py
+++ b/plugins/influxdb/alerta_influxdb.py
@@ -42,7 +42,8 @@ class InfluxDBWrite(PluginBase):
                 "measurement": alert.event,
                 "tags": {
                     "resource": alert.resource,
-                    "environment": alert.environment
+                    "environment": alert.environment,
+                    "severity": alert.severity
                 },
                 "time": alert.last_receive_time,
                 "fields": {


### PR DESCRIPTION
We wanted to record severity as a tag in InfluxDB when using this plugin.  I've added it as a single line where other tags are defined.