### PR TITLE
Make everything MIT license

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -2,16 +2,22 @@ Aivars Šterns <asterns@evolutiongaming.com>
 Angel Velasquez <avelasquez@sangoma.com>
 Angel Velásquez <angvp@archlinux.org>
 Angel Velásquez <avelasquez@sangoma.com>
+Arindam Choudhury <arindam@live.com>
+Christian Blunden <christian.blunden@gmail.com>
 int32bit <krystism@gmail.com>
 Jacek Grzechnik <jacek.grzechnik@mbank.pl>
 Joao Mesquita <jmesquita@sangoma.com>
 Marco <marco@supino.org>
+Marco Supino <marco@drivenets.net>
+marksmyth <smythmark1980@gmail.com>
 Minh Danh <minhdanh@hoiio.com>
 Moises Silva <msilva@sangoma.com>
 Nick Satterly <nick.satterly@theguardian.com>
 Rafael Matias <rafael.matias@centralway.com>
 root <root@ubu001.pod01.secdo.net>
+Scott Mullaly <scott.mullaly@orionhealth.com>
 SK <skobolo@gmail.com>
+thehill <thehill@users.noreply.github.com>
 Карамышев Степан <karamyshev@corp.sputnik.ru>
 
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2014-2016 Nick Satterly
+Copyright (c) 2014-2017 Nick Satterly and AUTHORS
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -54,5 +54,5 @@ Plugins
 License
 -------
 
-Copyright (c) 2014-2017 Nick Satterly. Available under the MIT License.
+Copyright (c) 2014-2017 Nick Satterly and [AUTHORS](AUTHORS). Available under the MIT License.
 

--- a/integrations/mailer/README.md
+++ b/integrations/mailer/README.md
@@ -161,4 +161,4 @@ To execute unit-tests run:
 License
 -------
 
-Copyright (c) 2015-2016 Nick Satterly and [AUTHORS](AUTHORS). Available under the MIT License.
+Copyright (c) 2015-2016 Nick Satterly and [AUTHORS](/AUTHORS). Available under the MIT License.

--- a/integrations/snmptrap/setup.py
+++ b/integrations/snmptrap/setup.py
@@ -7,7 +7,7 @@ setuptools.setup(
     version='3.3.2',
     description='Alerta script for SNMP traps',
     url='https://github.com/alerta/alerta-contrib',
-    license='Apache License 2.0',
+    license='MIT',
     author='Nick Satterly',
     author_email='nick.satterly@theguardian.com',
     py_modules=['handler'],

--- a/integrations/sqs/setup.py
+++ b/integrations/sqs/setup.py
@@ -9,7 +9,7 @@ setuptools.setup(
     version=version,
     description='Alerta integration for AWS SQS',
     url='https://github.com/alerta/alerta-contrib',
-    license='Apache License 2.0',
+    license='MIT',
     author='Nick Satterly',
     author_email='nick.satterly@theguardian.com',
     py_modules=['alerta_sqs'],

--- a/integrations/syslog/setup.py
+++ b/integrations/syslog/setup.py
@@ -9,7 +9,7 @@ setuptools.setup(
     version=version,
     description='Alerta script for Syslog messages',
     url='https://github.com/alerta/alerta-contrib',
-    license='Apache License 2.0',
+    license='MIT',
     author='Nick Satterly',
     author_email='nick.satterly@theguardian.com',
     py_modules=['syslogfwder'],

--- a/integrations/urlmon/setup.py
+++ b/integrations/urlmon/setup.py
@@ -9,7 +9,7 @@ setuptools.setup(
     version=version,
     description='Alerta script for URL monitoring',
     url='https://github.com/alerta/alerta-contrib',
-    license='Apache License 2.0',
+    license='MIT',
     author='Nick Satterly',
     author_email='nick.satterly@theguardian.com',
     py_modules=['urlmon'],

--- a/plugins/amqp/setup.py
+++ b/plugins/amqp/setup.py
@@ -8,7 +8,7 @@ setup(
     version=version,
     description='Alerta plugin for AMQP messaging',
     url='https://github.com/alerta/alerta-contrib',
-    license='Apache License 2.0',
+    license='MIT',
     author='Nick Satterly',
     author_email='nick.satterly@theguardian.com',
     packages=find_packages(),

--- a/plugins/cachet/setup.py
+++ b/plugins/cachet/setup.py
@@ -8,7 +8,7 @@ setup(
     version=version,
     description='Alerta plugin for Cachet status page',
     url='https://github.com/alerta/alerta-contrib',
-    license='Apache License 2.0',
+    license='MIT',
     author='Nick Satterly',
     author_email='nick.satterly@theguardian.com',
     packages=find_packages(),

--- a/plugins/enhance/setup.py
+++ b/plugins/enhance/setup.py
@@ -8,7 +8,7 @@ setup(
     version=version,
     description='Alerta plugin for alert enhancement',
     url='https://github.com/alerta/alerta-contrib',
-    license='Apache License 2.0',
+    license='MIT',
     author='Nick Satterly',
     author_email='nick.satterly@theguardian.com',
     packages=find_packages(),

--- a/plugins/geoip/setup.py
+++ b/plugins/geoip/setup.py
@@ -8,7 +8,7 @@ setup(
     version=version,
     description='Alerta plugin for GeoIP Lookup',
     url='https://github.com/alerta/alerta-contrib',
-    license='Apache License 2.0',
+    license='MIT',
     author='Nick Satterly',
     author_email='nick.satterly@theguardian.com',
     packages=find_packages(),

--- a/plugins/hipchat/setup.py
+++ b/plugins/hipchat/setup.py
@@ -8,7 +8,7 @@ setup(
     version=version,
     description='Alerta plugin for HipChat',
     url='https://github.com/alerta/alerta-contrib',
-    license='Apache License 2.0',
+    license='MIT',
     author='Nick Satterly',
     author_email='nick.satterly@theguardian.com',
     packages=find_packages(),

--- a/plugins/influxdb/setup.py
+++ b/plugins/influxdb/setup.py
@@ -8,7 +8,7 @@ setup(
     version=version,
     description='Alerta plugin for InfluxDB v1.1',
     url='https://github.com/alerta/alerta-contrib',
-    license='Apache License 2.0',
+    license='MIT',
     author='Nick Satterly',
     author_email='nick.satterly@theguardian.com',
     packages=find_packages(),

--- a/plugins/logstash/setup.py
+++ b/plugins/logstash/setup.py
@@ -8,7 +8,7 @@ setup(
     version=version,
     description='Alerta plugin for ELK logstash',
     url='https://github.com/alerta/alerta-contrib',
-    license='Apache License 2.0',
+    license='MIT',
     author='Nick Satterly',
     author_email='nick.satterly@theguardian.com',
     packages=find_packages(),

--- a/plugins/normalise/setup.py
+++ b/plugins/normalise/setup.py
@@ -8,7 +8,7 @@ setup(
     version=version,
     description='Alerta plugin for alert normalisation',
     url='https://github.com/alerta/alerta-contrib',
-    license='Apache License 2.0',
+    license='MIT',
     author='Nick Satterly',
     author_email='nick.satterly@theguardian.com',
     packages=find_packages(),

--- a/plugins/pagerduty/setup.py
+++ b/plugins/pagerduty/setup.py
@@ -8,7 +8,7 @@ setup(
     version=version,
     description='Alerta plugin for PagerDuty',
     url='https://github.com/alerta/alerta-contrib',
-    license='Apache License 2.0',
+    license='MIT',
     author='Nick Satterly',
     author_email='nick.satterly@theguardian.com',
     packages=find_packages(),

--- a/plugins/prometheus/setup.py
+++ b/plugins/prometheus/setup.py
@@ -8,7 +8,7 @@ setup(
     version=version,
     description='Alerta plugin for Prometheus Alertmanager',
     url='https://github.com/alerta/alerta-contrib',
-    license='Apache License 2.0',
+    license='MIT',
     author='Nick Satterly',
     author_email='nick.satterly@theguardian.com',
     packages=find_packages(),

--- a/plugins/pubsub/setup.py
+++ b/plugins/pubsub/setup.py
@@ -8,7 +8,7 @@ setup(
     version=version,
     description='Alerta plugin for sending alerts to pubsub',
     url='https://github.com/alerta/alerta-contrib',
-    license='Apache License 2.0',
+    license='MIT',
     author='Arindam Choudhury',
     author_email='arindam@live.com',
     packages=find_packages(),

--- a/plugins/sns/setup.py
+++ b/plugins/sns/setup.py
@@ -8,7 +8,7 @@ setup(
     version=version,
     description='Alerta plugin for AWS SNS',
     url='https://github.com/alerta/alerta-contrib',
-    license='Apache License 2.0',
+    license='MIT',
     author='Nick Satterly',
     author_email='nick.satterly@theguardian.com',
     packages=find_packages(),

--- a/plugins/twilio/setup.py
+++ b/plugins/twilio/setup.py
@@ -8,7 +8,7 @@ setup(
     version=version,
     description='Alerta plugin for Twilio SMS',
     url='https://github.com/alerta/alerta-contrib',
-    license='Apache License 2.0',
+    license='MIT',
     author='Nick Satterly',
     author_email='nick.satterly@theguardian.com',
     packages=find_packages(),


### PR DESCRIPTION
All the README files referred to using the MIT license but some python setup.py actually listed the Apache 2 license. This change makes sure everything is MIT license and that all current contrib AUTHORS are acknowledged.