### PR TITLE
Allow InfluxDB plugin to use a single measurement

### DIFF
--- a/plugins/influxdb/alerta_influxdb.py
+++ b/plugins/influxdb/alerta_influxdb.py
@@ -9,10 +9,16 @@ from influxdb import InfluxDBClient
 
 LOG = logging.getLogger('alerta.plugins.influxdb')
 
-DEFAULT_INFLUXDB_DSN = 'influxdb://user:pass@localhost:8086/alerta' # 'influxdb://username:password@localhost:8086/databasename'
+DEFAULT_INFLUXDB_DSN = 'influxdb://user:pass@localhost:8086/alerta'  # 'influxdb://username:password@localhost:8086/databasename'
 
 INFLUXDB_DSN = os.environ.get('INFLUXDB_DSN') or app.config.get('INFLUXDB_DSN', DEFAULT_INFLUXDB_DSN)
 INFLUXDB_DATABASE = os.environ.get('INFLUXDB_DATABASE') or app.config.get('INFLUXDB_DATABASE', None)
+
+# Specify the name of a combined measurement to which all alerts will be logged
+INFLUXDB_SINGLE_MEASUREMENT = os.environ.get('INFLUXDB_SINGLE_MEASUREMENT') or app.config.get('INFLUXDB_SINGLE_MEASUREMENT', False)
+
+# Specify True or False to log alerts to individual measurements (defaults to True)
+INFLUXDB_SEPARATE_MEASUREMENT = True if os.environ.get('INFLUXDB_SEPARATE_MEASUREMENT', 'False') == 'True' else app.config.get('INFLUXDB_SEPARATE_MEASUREMENT', True)
 
 
 class InfluxDBWrite(PluginBase):
@@ -37,20 +43,38 @@ class InfluxDBWrite(PluginBase):
     def post_receive(self, alert):
 
         # event data
-        points = [
-            {
-                "measurement": alert.event,
-                "tags": {
-                    "resource": alert.resource,
-                    "environment": alert.environment,
-                    "severity": alert.severity
-                },
-                "time": alert.last_receive_time,
-                "fields": {
-                    "value": alert.value
+        points = []
+        if INFLUXDB_SEPARATE_MEASUREMENT:
+            points += [
+                {
+                    "measurement": alert.event,
+                    "tags": {
+                        "resource": alert.resource,
+                        "environment": alert.environment,
+                        "severity": alert.severity
+                    },
+                    "time": alert.last_receive_time,
+                    "fields": {
+                        "value": str(alert.value)
+                    }
                 }
-            }
-        ]
+            ]
+        if INFLUXDB_SINGLE_MEASUREMENT:
+            points += [
+                {
+                    "measurement": INFLUXDB_SINGLE_MEASUREMENT,
+                    "tags": {
+                        "event": alert.event,
+                        "resource": alert.resource,
+                        "environment": alert.environment,
+                        "severity": alert.severity
+                    },
+                    "time": alert.last_receive_time,
+                    "fields": {
+                        "value": str(alert.value)
+                    }
+                }
+            ]
 
         # common tags
         tags = {"service": ','.join(alert.service)}
@@ -60,7 +84,8 @@ class InfluxDBWrite(PluginBase):
         LOG.debug('InfluxDB: points=%s, tags=%s', points, tags)
 
         try:
-            self.client.write_points(points, time_precision='ms', tags=tags)
+            if points:
+                self.client.write_points(points, time_precision='ms', tags=tags)
         except Exception as e:
             raise RuntimeError("InfluxDB: ERROR - %s" % e)
 

--- a/plugins/influxdb/setup.py
+++ b/plugins/influxdb/setup.py
@@ -1,7 +1,7 @@
 
 from setuptools import setup, find_packages
 
-version = '0.3.3'
+version = '0.3.3-combined2'
 
 setup(
     name="alerta-influxdb",


### PR DESCRIPTION
I wanted to provide an option to output to a single InfluxDB measurement rather than one per event

The default behavior is to create one measurement per alert.event in InfluxDB.  Some uses of InfluxDB are easier if all Alerta data is available in a single measurement with a tag that indicates alert.event.

This introduces two new config variables:

INFLUXDB_SEPARATE_MEASUREMENT defaults to True and triggers the default (separate measurement per event) behavior.

INFLUXDB_SINGLE_MEASUREMENT defaults to False and triggers the new behavior of one measurement for all events.  If set it should be set to the name of the measurement you want to use (e.g. not True but rather "alert_measurement").

Both behaviors can be either enabled or disabled (i.e. it isn't one or the other behavior...you can have both).  If neither variable is set (for example if someone installs this code but does not change the config file) the behavior remains at the old default (one measurement per alert name).

The InfluxDB points now start as an empty list (line 46).  If either of the above config variables are not False a point is added to the list in the format appropriate for that setting.  In the case of INFLUXDB_SEPARATE_MEASUREMENT (default behavior) this is unchanged from the original behavior and schema.

In the case of INFLUXDB_SINGLE_MEASUREMENT (new behavior) this point uses the value set in INFLUXDB_SINGLE_MEASUREMENT as a measurement name and adds a new tag called "event" which is populated with the alert.event value.

I've made one other change to each point type which is to coerce the value field (alert.value in both cases) to a string.  The issue we ran into is that InfluxDB defines a field's type based on the first point.  If the first point is a string the old code worked fine (subsequent numeric values were treated as strings), but if the first point was numeric InfluxDB would drop subsequent points that included string values.  Since Alerta allows string values (and has to it would seem) I've forced this field to be a string in InfluxDB.

Finally within the final try block to write points to InfluxDB I changed this to only do so if the points list is not empty.  This handles the case where both configuration variables are false and nothing is written.

One thing to consider is the behavior of the INFLUXDB_SINGLE_MEASUREMENT variable.  I've made it so that if set to False the new behavior is skipped, but if you want to enable the new behavior you set it to the value of the new measurement you want to use (so the valid values are False and `<name of a measurement>`).  That's not the most obvious thing, but I did it to minimize the number of settings you need.  Another option would be to have something along the lines of:

INFLUXDB_SINGLE_MEASUREMENT: True or False
INFLUXDB_SINGLE_MEASUREMENT_NAME:  string

where the second new option is only used if the first is True and defines the measurement name.