### PR TITLE
Add support for per environment alert channel

### DIFF
--- a/plugins/slack/README.md
+++ b/plugins/slack/README.md
@@ -37,10 +37,11 @@ To configure the Slack plugin start by setting up an
 [incoming webhook integration](https://my.slack.com/services/new/incoming-webhook/)
 for your Slack channel and adding the following configuration settings to `alertad.conf`:
 
-```
+```python
 SLACK_WEBHOOK_URL = 'https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX'
 SLACK_ATTACHMENTS = True  # default=False
 SLACK_CHANNEL = '' # if empty then uses channel from incoming webhook configuration
+SLACK_CHANNEL_ENV_MAP = { 'Production' : '#alert-prod' } # Default=None (optionnal) Allow to specify a channel on a per-environment basis. SLACK_CHANNEL is used a default value
 
 ICON_EMOJI = '' # default :rocket:
 ALERTA_USERNAME = '' # default alerta

--- a/plugins/slack/alerta_slack.py
+++ b/plugins/slack/alerta_slack.py
@@ -12,7 +12,7 @@ LOG = logging.getLogger('alerta.plugins.slack')
 SLACK_WEBHOOK_URL = os.environ.get('SLACK_WEBHOOK_URL') or app.config['SLACK_WEBHOOK_URL']
 SLACK_ATTACHMENTS = True if os.environ.get('SLACK_ATTACHMENTS', 'False') == 'True' else app.config.get('SLACK_ATTACHMENTS', False)
 SLACK_CHANNEL = os.environ.get('SLACK_CHANNEL') or app.config.get('SLACK_CHANNEL', '')
-SLACK_CHANNEL_ENV_MAP = os.environ.get('SLACK_CHANNEL_ENV_MAP') or app.config.get('SLACK_CHANNEL_ENV_MAP', None)
+SLACK_CHANNEL_ENV_MAP = os.environ.get('SLACK_CHANNEL_ENV_MAP') or app.config.get('SLACK_CHANNEL_ENV_MAP', dict())
 ALERTA_USERNAME = os.environ.get('ALERTA_USERNAME') or app.config.get('ALERTA_USERNAME', 'alerta')
 
 ICON_EMOJI = os.environ.get('ICON_EMOJI') or app.config.get('ICON_EMOJI', ':rocket:')
@@ -54,9 +54,7 @@ class ServiceIntegration(PluginBase):
         else:
             color = "#00CC00"  # green
 
-        channel = SLACK_CHANNEL
-        if not SLACK_CHANNEL_ENV_MAP is None:
-            channel = SLACK_CHANNEL_ENV_MAP.get(alert.environment, SLACK_CHANNEL)
+        channel = SLACK_CHANNEL_ENV_MAP.get(alert.environment, SLACK_CHANNEL)
 
         text = "<%s/#/alert/%s|%s> %s - %s" % (DASHBOARD_URL, alert.get_id(), alert.get_id(short=True), alert.event, alert.text)
 

--- a/plugins/slack/alerta_slack.py
+++ b/plugins/slack/alerta_slack.py
@@ -12,6 +12,7 @@ LOG = logging.getLogger('alerta.plugins.slack')
 SLACK_WEBHOOK_URL = os.environ.get('SLACK_WEBHOOK_URL') or app.config['SLACK_WEBHOOK_URL']
 SLACK_ATTACHMENTS = True if os.environ.get('SLACK_ATTACHMENTS', 'False') == 'True' else app.config.get('SLACK_ATTACHMENTS', False)
 SLACK_CHANNEL = os.environ.get('SLACK_CHANNEL') or app.config.get('SLACK_CHANNEL', '')
+SLACK_CHANNEL_ENV_MAP = os.environ.get('SLACK_CHANNEL_ENV_MAP') or app.config.get('SLACK_CHANNEL_ENV_MAP', None)
 ALERTA_USERNAME = os.environ.get('ALERTA_USERNAME') or app.config.get('ALERTA_USERNAME', 'alerta')
 
 ICON_EMOJI = os.environ.get('ICON_EMOJI') or app.config.get('ICON_EMOJI', ':rocket:')
@@ -53,13 +54,17 @@ class ServiceIntegration(PluginBase):
         else:
             color = "#00CC00"  # green
 
+        channel = SLACK_CHANNEL
+        if not SLACK_CHANNEL_ENV_MAP is None:
+            channel = SLACK_CHANNEL_ENV_MAP.get(alert.environment, SLACK_CHANNEL)
+
         text = "<%s/#/alert/%s|%s> %s - %s" % (DASHBOARD_URL, alert.get_id(), alert.get_id(short=True), alert.event, alert.text)
 
         if not SLACK_ATTACHMENTS:
 
             payload = {
                 "username": ALERTA_USERNAME,
-                "channel": SLACK_CHANNEL,
+                "channel": channel,
                 "text": summary,
                 "icon_emoji": ICON_EMOJI
             }
@@ -67,7 +72,7 @@ class ServiceIntegration(PluginBase):
         else:
             payload = {
                 "username": ALERTA_USERNAME,
-                "channel": SLACK_CHANNEL,
+                "channel": channel,
                 "icon_emoji": ICON_EMOJI,
                 "attachments": [{
                     "fallback": summary,


### PR DESCRIPTION
By adding a new optionnal setting, it is now possible to setup some dedicated slack channels for posting channels.