### PR TITLE
Slack message upon ack and override severity maps

### DIFF
--- a/plugins/slack/alerta_slack.py
+++ b/plugins/slack/alerta_slack.py
@@ -9,64 +9,69 @@ from alerta.plugins import PluginBase
 
 LOG = logging.getLogger('alerta.plugins.slack')
 
-SLACK_WEBHOOK_URL = os.environ.get('SLACK_WEBHOOK_URL') or app.config['SLACK_WEBHOOK_URL']
-SLACK_ATTACHMENTS = True if os.environ.get('SLACK_ATTACHMENTS', 'False') == 'True' else app.config.get('SLACK_ATTACHMENTS', False)
-SLACK_CHANNEL = os.environ.get('SLACK_CHANNEL') or app.config.get('SLACK_CHANNEL', '')
-SLACK_CHANNEL_ENV_MAP = os.environ.get('SLACK_CHANNEL_ENV_MAP') or app.config.get('SLACK_CHANNEL_ENV_MAP', dict())
-ALERTA_USERNAME = os.environ.get('ALERTA_USERNAME') or app.config.get('ALERTA_USERNAME', 'alerta')
+SLACK_WEBHOOK_URL = os.environ.get(
+    'SLACK_WEBHOOK_URL') or app.config['SLACK_WEBHOOK_URL']
+SLACK_ATTACHMENTS = True if os.environ.get(
+    'SLACK_ATTACHMENTS', 'False') == 'True' else app.config.get('SLACK_ATTACHMENTS', False)
+SLACK_CHANNEL = os.environ.get(
+    'SLACK_CHANNEL') or app.config.get('SLACK_CHANNEL', '')
+SLACK_CHANNEL_ENV_MAP = os.environ.get(
+    'SLACK_CHANNEL_ENV_MAP') or app.config.get('SLACK_CHANNEL_ENV_MAP', dict())
+ALERTA_USERNAME = os.environ.get(
+    'ALERTA_USERNAME') or app.config.get('ALERTA_USERNAME', 'alerta')
+SLACK_SEND_ON_ACK = os.environ.get(
+    'SLACK_SEND_ON_ACK') or app.config.get('SLACK_SEND_ON_ACK', False)
+SLACK_SEVERITY_MAP = app.config.get('SLACK_SEVERITY_MAP', {})
+SLACK_DEFAULT_SEVERITY_MAP = {'security': '#000000', # black
+                              'critical': '#FF0000', # red
+                              'major': '#FFA500', # orange
+                              'minor': '#FFFF00', # yellow
+                              'warning': '#1E90FF', #blue
+                              'informational': '#808080', #gray
+                              'debug': '#808080', # gray
+                              'trace': '#808080', # gray
+                              'ok': '#00CC00'} # green
 
-ICON_EMOJI = os.environ.get('ICON_EMOJI') or app.config.get('ICON_EMOJI', ':rocket:')
-DASHBOARD_URL = os.environ.get('DASHBOARD_URL') or app.config.get('DASHBOARD_URL', '')
+ICON_EMOJI = os.environ.get('ICON_EMOJI') or app.config.get(
+    'ICON_EMOJI', ':rocket:')
+DASHBOARD_URL = os.environ.get(
+    'DASHBOARD_URL') or app.config.get('DASHBOARD_URL', '')
+
 
 class ServiceIntegration(PluginBase):
+    def __init__(self):
+        # override user-defined severities
+        self._severities = dict(SLACK_SEVERITY_MAP.items() +
+                          SLACK_DEFAULT_SEVERITY_MAP.items())
+
 
     def pre_receive(self, alert):
         return alert
 
-    def post_receive(self, alert):
-
-        if alert.repeat:
-            return
-
-        url = SLACK_WEBHOOK_URL
-
+    def _slack_prepare_payload(self, alert, status=None, text=None):
         summary = "*[%s] %s %s - _%s on %s_* <%s/#/alert/%s|%s>" % (
-            alert.status.capitalize(), alert.environment, alert.severity.capitalize(), alert.event, alert.resource, DASHBOARD_URL,
+            (status if status else alert.status).capitalize(), alert.environment, alert.severity.capitalize(
+            ), alert.event, alert.resource, DASHBOARD_URL,
             alert.id, alert.get_id(short=True)
         )
 
-        if alert.severity == 'security':
-            color = "#000000"  # black
-        if alert.severity == 'critical':
-            color = "#FF0000"  # red
-        elif alert.severity == 'major':
-            color = "#FFA500"  # orange
-        elif alert.severity == 'minor':
-            color = "#FFFF00"  # yellow
-        elif alert.severity == 'warning':
-            color = "#1E90FF"  # blue
-        elif alert.severity == 'informational':
-            color = "#808080"  # gray
-        elif alert.severity == 'debug':
-            color = "#808080"  # gray
-        elif alert.severity == 'trace':
-            color = "#808080"  # gray
+        if alert.severity in self._severities:
+            color = self._severities[alert.severity]
         else:
-            color = "#00CC00"  # green
+            color = '#00CC00'  # green
 
         channel = SLACK_CHANNEL_ENV_MAP.get(alert.environment, SLACK_CHANNEL)
 
-        text = "<%s/#/alert/%s|%s> %s - %s" % (DASHBOARD_URL, alert.get_id(), alert.get_id(short=True), alert.event, alert.text)
+        txt = "<%s/#/alert/%s|%s> %s - %s" % (DASHBOARD_URL, alert.get_id(
+        ), alert.get_id(short=True), alert.event, text if text else alert.text)
 
         if not SLACK_ATTACHMENTS:
-
             payload = {
                 "username": ALERTA_USERNAME,
                 "channel": channel,
                 "text": summary,
                 "icon_emoji": ICON_EMOJI
             }
-
         else:
             payload = {
                 "username": ALERTA_USERNAME,
@@ -75,24 +80,49 @@ class ServiceIntegration(PluginBase):
                 "attachments": [{
                     "fallback": summary,
                     "color": color,
-                    "pretext": text,
+                    "pretext": txt,
                     "fields": [
-                        {"title": "Status", "value": alert.status.capitalize(), "short": True},
-                        {"title": "Environment", "value": alert.environment, "short": True},
+                        {"title": "Status", "value": (status if status else alert.status).capitalize(),
+                         "short": True},
+                        {"title": "Environment",
+                            "value": alert.environment, "short": True},
                         {"title": "Resource", "value": alert.resource, "short": True},
-                        {"title": "Services", "value": ", ".join(alert.service), "short": True}
+                        {"title": "Services", "value": ", ".join(
+                            alert.service), "short": True}
                     ]
                 }]
             }
 
+        return payload
+
+    def post_receive(self, alert):
+
+        if alert.repeat:
+            return
+
+        payload = self._slack_prepare_payload(alert)
+
         LOG.debug('Slack payload: %s', payload)
 
         try:
-            r = requests.post(url, data=json.dumps(payload), timeout=2)
+            r = requests.post(SLACK_WEBHOOK_URL,
+                              data=json.dumps(payload), timeout=2)
         except Exception as e:
             raise RuntimeError("Slack connection error: %s", e)
 
         LOG.debug('Slack response: %s', r.status_code)
 
     def status_change(self, alert, status, text):
-        return
+        if SLACK_SEND_ON_ACK == False or status not in ['ack', 'assign']:
+            return
+
+        payload = self._slack_prepare_payload(alert, status, text)
+
+        LOG.debug('Slack payload: %s', payload)
+        try:
+            r = requests.post(SLACK_WEBHOOK_URL,
+                              data=json.dumps(payload), timeout=2)
+        except Exception as e:
+            raise RuntimeError("Slack connection error: %s", e)
+
+        LOG.debug('Slack response: %s', r.status_code)

--- a/plugins/slack/setup.py
+++ b/plugins/slack/setup.py
@@ -1,7 +1,7 @@
 
 from setuptools import setup, find_packages
 
-version = '0.3.3'
+version = '0.3.4'
 
 setup(
     name="alerta-slack",


### PR DESCRIPTION
This PR adds support for the followings:

* optionally send a slack notification when an alert transitions to ack. The behavior is driven by the SLACK_SEND_ON_ACK boolean variable.
* optionally override the default severities map via SLACK_SEVERITY_MAP. The behavior is actually a merge between the defaults (SLACK_DEFAULT_SEVERITY_MAP) and the user-defined dictionary.