### PR TITLE
Enable use of internally hosted Hipchat instances

### DIFF
--- a/plugins/hipchat/README.md
+++ b/plugins/hipchat/README.md
@@ -35,6 +35,8 @@ PLUGINS = ['hipchat']
 HIPCHAT_ROOM = 'alerts'
 HIPCHAT_API_KEY =  'W4Dll5plS0qrqXCpPwjwzF9pO2TJI2Oou9Xaq8je'
 DASHBOARD_URL = 'http://try.alerta.io'
+HIPCHAT_URL = 'https://api.hipchat.com/v2'
+HIPCHAT_VERIFY_SSL = True
 ```
 
 The `HIPCHAT_SUMMARY_FMT` configuration variable is a Jinja2 template

--- a/plugins/hipchat/alerta_hipchat.py
+++ b/plugins/hipchat/alerta_hipchat.py
@@ -9,10 +9,11 @@ from alerta.plugins import PluginBase
 
 LOG = logging.getLogger('alerta.plugins.hipchat')
 
-HIPCHAT_URL = 'https://api.hipchat.com/v2'
+HIPCHAT_URL = os.environ.get('HIPCHAT_URL') or app.config.get('HIPCHAT_URL', 'https://api.hipchat.com/v2') # Hipchat URL, change if using privately hosted Hipchat
 HIPCHAT_ROOM = os.environ.get('HIPCHAT_ROOM') or app.config['HIPCHAT_ROOM']  # Room Name or Room API ID
 HIPCHAT_API_KEY = os.environ.get('HIPCHAT_API_KEY') or app.config['HIPCHAT_API_KEY']  # Room Notification Token
 HIPCHAT_SUMMARY_FMT = os.environ.get('HIPCHAT_SUMMARY_FMT') or app.config.get('HIPCHAT_SUMMARY_FMT', None)  # Message summary format
+HIPCHAT_VERIFY_SSL = os.environ.get('HIPCHAT_VERIFY_SSL') or app.config.get('HIPCHAT_VERIFY_SSL', True) # Verify SSL cert from Hipchat
 DASHBOARD_URL = os.environ.get('DASHBOARD_URL') or app.config.get('DASHBOARD_URL', '')
 
 try:
@@ -87,7 +88,7 @@ class SendRoomNotification(PluginBase):
 
         LOG.debug('HipChat: Notification sent to %s', url)
         try:
-            r = requests.post(url, data=json.dumps(payload), headers=headers, timeout=2)
+            r = requests.post(url, data=json.dumps(payload), headers=headers, timeout=2, verify=HIPCHAT_VERIFY_SSL)
         except Exception as e:
             raise RuntimeError("HipChat: ERROR - %s", e)
 

--- a/plugins/hipchat/setup.py
+++ b/plugins/hipchat/setup.py
@@ -1,7 +1,7 @@
 
 from setuptools import setup, find_packages
 
-version = '0.3.2'
+version = '0.3.3'
 
 setup(
     name="alerta-hipchat",


### PR DESCRIPTION
Added a couple of extra config options to allow use of privately hosted Hipchat instances:
 - HIPCHAT_URL (seems obvious)
 - HIPCHAT_VERIFY_SSL - allow disable of Python's SSL verification in case of self-signed or internal SSL certs