### PR TITLE
InfluxDB plugin improvements

### DIFF
--- a/plugins/influxdb/setup.py
+++ b/plugins/influxdb/setup.py
@@ -1,7 +1,7 @@
 
 from setuptools import setup, find_packages
 
-version = '0.4.0'
+version = '0.4.1'
 
 setup(
     name="alerta-influxdb",


### PR DESCRIPTION
I've made the following changes to the InfluxDB plugin:

* add the alert tags in the format of `k=v` to the InfluxDB metric point as tags
* retain metric point value type if it's a digit (float, int)
* add status as a tag to InfluxDB metric point
* send alert status changes to InfluxDB (ack and assign). Add `text` as an optional field.