### PR TITLE
Publish utc-aware datetimes in AMQP plugin

### DIFF
--- a/plugins/amqp/alerta_amqp.py
+++ b/plugins/amqp/alerta_amqp.py
@@ -1,6 +1,7 @@
 
 import logging
 import os
+import pytz
 
 from kombu import BrokerConnection, Exchange, Producer
 from kombu.utils.debug import setup_logging
@@ -51,6 +52,9 @@ class FanoutPublisher(PluginBase):
 
         try:
             body = alert.serialize  # alerta >= 5.0
+
+            # update body's datetime-related fields  with utc-aware values
+            body.update({key: body[key].replace(tzinfo=pytz.utc) for key in ['createTime', 'lastReceiveTime', 'receiveTime']})
         except Exception:
             body = alert.get_body()  # alerta < 5.0
 

--- a/plugins/amqp/setup.py
+++ b/plugins/amqp/setup.py
@@ -1,7 +1,7 @@
 
 from setuptools import setup, find_packages
 
-version = '5.4.0'
+version = '5.4.1'
 
 setup(
     name="alerta-amqp",
@@ -14,7 +14,8 @@ setup(
     packages=find_packages(),
     py_modules=['alerta_amqp'],
     install_requires=[
-        'kombu'
+        'kombu',
+        'pytz'
     ],
     include_package_data=True,
     zip_safe=True,


### PR DESCRIPTION
## Issue
After upgrading to alerta-server to 5.x, `alerta-mailer` produced the following error:
```
WARNING:mailer:dates must be ISO 8601 date format YYYY-MM-DDThh:mm:ss.sssZ
dates must be ISO 8601 date format YYYY-MM-DDThh:mm:ss.sssZ
```
Issue seems to appear during alert serialization in amqp plugin. Alert fields that contain datetime objects don't serialize as expected  -due to missing tzinfo- and produce date strings with missing 'Z'. 

## Fix
_Avoided to implement the fix centrally (e.g. in `alerta models alert.serialize`)_ 

The following refactoring in amqp plugin resolves the issue:
- After alert serialization (in ver 5.x) update body's datetime related fields with utc-aware values 
