### PR TITLE
Replace alert.get_date() with alert.create_time

### DIFF
--- a/plugins/pushover/alerta_pushover.py
+++ b/plugins/pushover/alerta_pushover.py
@@ -57,7 +57,7 @@ class PushMessage(PluginBase):
             "url": '%s/#/alert/%s' % (DASHBOARD_URL, alert.id),
             "url_title": "View alert",
             "priority": priority,
-            "timestamp": int(alert.get_date('create_time', fmt='epoch')),
+            "timestamp": alert.create_time,
             "sound": "tugboat"
         }
 


### PR DESCRIPTION
At some stage, the `Alert` class had a `get_date()` method but it doesn't seem to anymore.