### PR TITLE
fix bug: return directly if not zabbixAlert to avoid zabbix login error

### DIFF
--- a/plugins/zabbix/alerta_zabbix.py
+++ b/plugins/zabbix/alerta_zabbix.py
@@ -32,12 +32,12 @@ class ZabbixEventAck(PluginBase):
 
     def status_change(self, alert, status, text):
 
+        if alert.event_type != 'zabbixAlert':
+            return
+
         zabbix_api_url = ZABBIX_API_URL or alert.attributes.get('zabbixUrl', DEFAULT_ZABBIX_API_URL)
         self.zapi = ZabbixAPI(zabbix_api_url)
         self.zapi.login(ZABBIX_USER, ZABBIX_PASSWORD)
-
-        if alert.event_type != 'zabbixAlert':
-            return
 
         if alert.status == status or not status in ['ack', 'closed']:
             return

--- a/plugins/zabbix/setup.py
+++ b/plugins/zabbix/setup.py
@@ -1,7 +1,7 @@
 
 from setuptools import setup, find_packages
 
-version = '5.0.3'
+version = '5.0.4'
 
 setup(
     name="alerta-zabbix",


### PR DESCRIPTION
Zabbix plugin will try login even if not zabbixAlert,
return directly if not zabbixAlert. 