### PR TITLE
the dict.iteritems doesn't exist anymore in py3.

### DIFF
--- a/integrations/mailer/email.html.tmpl
+++ b/integrations/mailer/email.html.tmpl
@@ -16,7 +16,7 @@
 <strong>Duplicate Count</strong>: {{ alert.duplicate_count }} <br>
 <strong>Origin</strong>: {{ alert.origin }} <br>
 <strong>Tags</strong>: {{ alert.tags|join(', ') }} <br>
-{% for key,value in alert.attributes.iteritems() -%} 
+{% for key,value in alert.attributes.items() -%} 
 {{ key|title }}: {{ value }}
 {% endfor -%}
 <br>

--- a/integrations/mailer/email.tmpl
+++ b/integrations/mailer/email.tmpl
@@ -17,7 +17,7 @@ Text: {{ alert.text }}
 Duplicate Count: {{ alert.duplicate_count }}
 Origin: {{ alert.origin }}
 Tags: {{ alert.tags|join(', ') }}
-{% for key,value in alert.attributes.iteritems() -%}
+{% for key,value in alert.attributes.items() -%}
 {{ key|title }}: {{ value }}
 {% endfor -%}
 


### PR DESCRIPTION
The itermitems doesn't exist anymore in Python 3, so the templating fail.

items exists in both Py2 and Py3, they are a little different :
- in py3, items works as iteritems, using an iterator
- in py2, items use a copy of the list of items (it's a little less performant, but considerating the use case, it is not really important)