### PR TITLE
Add support for Slack "Apps" API instead of Webhook API

### DIFF
--- a/plugins/slack/README.md
+++ b/plugins/slack/README.md
@@ -55,6 +55,19 @@ the Alerta console:
 DASHBOARD_URL = ''  # default="not set"
 ```
 
+Slack Apps API
+--------------
+To use the Slack "Apps" API instead of an Incoming Webhook, create an application and 
+obtain its OAuth token.  Use that to set ```SLACK_TOKEN``` and specify the 
+URL endpoint to the new API entrypoint this way:
+
+```python
+SLACK_WEBHOOK_URL = 'https://slack.com/api/chat.postMessage'
+SLACK_TOKEN = 'xoxp-903711738716-407999999999-433333333331-a844444444488888888822222222220c'
+```
+
+Ensure SLACK_CHANNEL is set for the default channel for alerts.  You may still use SLACK_CHANNEL_ENV_MAP.
+
 
 References
 ----------

--- a/plugins/slack/alerta_slack.py
+++ b/plugins/slack/alerta_slack.py
@@ -40,7 +40,12 @@ ICON_EMOJI = os.environ.get('ICON_EMOJI') or app.config.get(
     'ICON_EMOJI', ':rocket:')
 DASHBOARD_URL = os.environ.get(
     'DASHBOARD_URL') or app.config.get('DASHBOARD_URL', '')
-
+SLACK_HEADERS = {
+    'Content-Type': 'application/json'
+}
+SLACK_TOKEN = os.environ.get('SLACK_TOKEN') or app.config['SLACK_TOKEN']
+if SLACK_TOKEN:
+    SLACK_HEADERS['Authorization'] = 'Bearer ' + SLACK_TOKEN
 
 class ServiceIntegration(PluginBase):
 
@@ -112,11 +117,11 @@ class ServiceIntegration(PluginBase):
 
         try:
             r = requests.post(SLACK_WEBHOOK_URL,
-                              data=json.dumps(payload), timeout=2)
+                              data=json.dumps(payload), headers=SLACK_HEADERS, timeout=2)
         except Exception as e:
             raise RuntimeError("Slack connection error: %s", e)
 
-        LOG.debug('Slack response: %s', r.status_code)
+        LOG.debug('Slack response: %s\n%s' % (r.status_code, r.text))
 
     def status_change(self, alert, status, text):
         if SLACK_SEND_ON_ACK == False or status not in ['ack', 'assign']:
@@ -127,8 +132,8 @@ class ServiceIntegration(PluginBase):
         LOG.debug('Slack payload: %s', payload)
         try:
             r = requests.post(SLACK_WEBHOOK_URL,
-                              data=json.dumps(payload), timeout=2)
+                              data=json.dumps(payload), headers=SLACK_HEADERS, timeout=2)
         except Exception as e:
             raise RuntimeError("Slack connection error: %s", e)
 
-        LOG.debug('Slack response: %s', r.status_code)
+        LOG.debug('Slack response: %s\n%s' % (r.status_code, r.text))


### PR DESCRIPTION
Allows the use of "channel" when posting to slack.  As of some time ago, the Webhook API stopped supporting setting channel, and instead solely relied on the associated channel established during app install.