### PR TITLE
Allow TELEGRAM_TEMPLATE to be a string

### DIFF
--- a/plugins/telegram/alerta_telegram.py
+++ b/plugins/telegram/alerta_telegram.py
@@ -48,9 +48,12 @@ class TelegramBot(PluginBase):
             LOG.debug('Telegram: %s', self.bot.getWebhookInfo())
 
         super(TelegramBot, self).__init__(name)
-        if TELEGRAM_TEMPLATE and os.path.exists(TELEGRAM_TEMPLATE):
-            with open(TELEGRAM_TEMPLATE, 'r') as f:
-                self.template = Template(f.read())
+        if TELEGRAM_TEMPLATE:
+            if os.path.exists(TELEGRAM_TEMPLATE):
+                with open(TELEGRAM_TEMPLATE, 'r') as f:
+                    self.template = Template(f.read())
+            else:
+                self.template = Template(TELEGRAM_TEMPLATE)
         else:
             self.template = Template(DEFAULT_TMPL)
 


### PR DESCRIPTION
This way it is much more comfortable to configure this addon, no extra volumes are needed.