### PR TITLE
Add support for BasicAuth to prometheus plugin

### DIFF
--- a/plugins/prometheus/README.md
+++ b/plugins/prometheus/README.md
@@ -48,6 +48,24 @@ ALERTMANAGER_API_URL = 'http://demo.robustperception.io:9093'  # default=http://
 ALERTMANAGER_SILENCE_DAYS = 2  # default=1
 ```
 
+Authentication
+--------------
+
+Prometheus Alertmanager [does not provide any form of authentication][1] by
+default. For convenience, this plugin will support Basic Auth if it has
+been configured (using a reverse proxy or otherwise). Any other form of
+authentication will require development work by the user.
+
+[1]: (https://prometheus.io/docs/operating/security/#authentication-authorization-and-encryption)
+
+**Example of BasicAuth configuration**
+
+```python
+ALERTMANAGER_API_URL = 'http://localhost:9093'
+ALERTMANAGER_USERNAME = 'promuser'
+ALERTMANAGER_PASSWORD = 'prompass'
+```
+
 Troubleshooting
 ---------------
 

--- a/plugins/prometheus/setup.py
+++ b/plugins/prometheus/setup.py
@@ -1,7 +1,7 @@
 
 from setuptools import setup, find_packages
 
-version = '5.3.6'
+version = '5.4.0'
 
 setup(
     name="alerta-prometheus",


### PR DESCRIPTION
**Example BasicAuth HTTP Request**

```
POST /api/v1/silences HTTP/1.1
Host: localhost:8900
User-Agent: python-requests/2.19.1
Accept-Encoding: gzip, deflate
Accept: */*
Connection: keep-alive
Content-Length: 233
Content-Type: application/json
Authorization: Basic cHJvbXVzZXI6cHJvbXBhc3M=

{"matchers": [{"name": "alertname", "value": "Bad"}, {"name": "instance", "value": "web02"}], "startsAt": "2018-09-11T08:08:36.000Z", "endsAt": "2018-09-12T08:08:36.000Z", "createdBy": "alerta", "comment": "status changed using CLI"}
```

Fixes #210 