### PR TITLE
Update Twilio plugin and support multiple destinations

### DIFF
--- a/plugins/twilio/setup.py
+++ b/plugins/twilio/setup.py
@@ -1,7 +1,7 @@
 
 from setuptools import setup, find_packages
 
-version = '5.3.1'
+version = '5.4.0'
 
 setup(
     name="alerta-twilio",
@@ -14,7 +14,7 @@ setup(
     packages=find_packages(),
     py_modules=['alerta_twilio_sms'],
     install_requires=[
-        'twilio'
+        'twilio>=6.0.0'
     ],
     include_package_data=True,
     zip_safe=True,


### PR DESCRIPTION
Python SDK has changed https://www.twilio.com/docs/libraries/python/usage-guide

Add support for multiple `TWILIO_TO_NUMBER` phone numbers (comma-separated)

**Example Twilio Plugin config**
```
PLUGINS=['twilio_sms']
TWILIO_ACCOUNT_SID='ACc1fba4719fd31c0e2a691xxxxxxxxx'
TWILIO_AUTH_TOKEN='4acd5e1ecde61ca0fbf11cexxxxxxxxxx'
TWILIO_FROM_NUMBER='+44123456789'
TWILIO_TO_NUMBER='+46987654321,+61324354657'
```
Fixes #155