### PR TITLE
WIP: Fix Opsgenie Alert Payload: teams attribute

### DIFF
--- a/plugins/opsgenie/alerta_opsgenie.py
+++ b/plugins/opsgenie/alerta_opsgenie.py
@@ -81,11 +81,13 @@ class TriggerEvent(PluginBase):
             details['previousSeverity'] = body['previousSeverity']
             details['duplicateCount'] = body['duplicateCount']
 
+            teams = []
+
             payload = {
                 "alias": alert.id,
                 "message": "[ %s ]: %s: %s" % (alert.environment, alert.severity, alert.text),
                 "entity": alert.environment,
-                "teams" : [],
+                "teams" : [{"name": team, "type": "team"} for team in teams],
                 "tags": [alert.environment, alert.resource, alert.service[0], alert.event],
                 "details": details
             }


### PR DESCRIPTION
Update teams attribute in Opsgenie Alert Payload in accordance with the [new API](https://docs.opsgenie.com/docs/alert-api#section-create-alert). 

The [migration guide](https://docs.opsgenie.com/docs/migration-guide-for-alert-rest-api#section-4-responders-field) for old API suggests in **Responders Section**

```responders field is introduced to Create Alerts instead of recipients and teams fields. Teams, users, escalations and schedules that you want to route the alert can be identified with IDs or names of them, and type key is mandatory for each.```
