### PR TITLE
Fix Opsgenie Alert Payload: teams attribute

### DIFF
--- a/plugins/opsgenie/alerta_opsgenie.py
+++ b/plugins/opsgenie/alerta_opsgenie.py
@@ -16,6 +16,7 @@ LOG.info('Initializing')
 OPSGENIE_EVENTS_CREATE_URL = 'https://api.opsgenie.com/v2/alerts'
 OPSGENIE_EVENTS_CLOSE_URL = 'https://api.opsgenie.com/v2/alerts/%s/close?identifierType=alias'
 OPSGENIE_SERVICE_KEY = os.environ.get('OPSGENIE_SERVICE_KEY') or app.config['OPSGENIE_SERVICE_KEY']
+OPSGENIE_TEAMS = os.environ.get('OPSGENIE_TEAMS', '') # comma separated list of teams
 SERVICE_KEY_MATCHERS = os.environ.get('SERVICE_KEY_MATCHERS') or app.config['SERVICE_KEY_MATCHERS']
 DASHBOARD_URL = os.environ.get('DASHBOARD_URL') or app.config.get('DASHBOARD_URL', '')
 LOG.info('Initialized: %s key, %s matchers' % (OPSGENIE_SERVICE_KEY, SERVICE_KEY_MATCHERS))
@@ -85,7 +86,7 @@ class TriggerEvent(PluginBase):
                 "alias": alert.id,
                 "message": "[ %s ]: %s: %s" % (alert.environment, alert.severity, alert.text),
                 "entity": alert.environment,
-                "teams" : [],
+                "responders" : self.get_opsgenie_teams(),
                 "tags": [alert.environment, alert.resource, alert.service[0], alert.event],
                 "details": details
             }
@@ -98,6 +99,14 @@ class TriggerEvent(PluginBase):
                 raise RuntimeError("OpsGenie connection error: %s" % e)
 
         LOG.debug('OpsGenie response: %s - %s' % (r.status_code, r.text))
+
+    # generate list of responders from OPSGENIE_TEAMS env var
+    def get_opsgenie_teams(self):
+        teams = OPSGENIE_TEAMS.replace(' ', '') # remove whitespace
+        if len(teams) == 0:
+            return [] # no teams specified
+        teams = teams.split(',')
+        return [{"name": team, "type": "team"} for team in teams]
 
     def status_change(self, alert, status, text):
         LOG.debug('Alert change %s to %s: %s' % (alert.id, status, alert.get_body(history=False)))


### PR DESCRIPTION
Update _teams_ attribute in Opsgenie Alert Payload in accordance with the [new API](https://docs.opsgenie.com/docs/alert-api#section-create-alert). 

The [migration guide](https://docs.opsgenie.com/docs/migration-guide-for-alert-rest-api#section-4-responders-field) for old API suggests in **Responders Section**

```responders field is introduced to Create Alerts instead of recipients and teams fields. Teams, users, escalations and schedules that you want to route the alert can be identified with IDs or names of them, and type key is mandatory for each.```

List of Changes:
* Taking OPSGENIE_TEAMS (string containing comma separated list of teams) as a environment variable 
* change **teams** key in payload to **responders** (acc. to new API)
* add a new function to convert the **OPSGENIE_TEAMS** to appropriate object before passing it in alert payload