### PR TITLE
msteams: Move url assignment out of else.

### DIFF
--- a/plugins/msteams/alerta_msteams.py
+++ b/plugins/msteams/alerta_msteams.py
@@ -57,8 +57,9 @@ class SendConnectorCardMessage(PluginBase):
                 event=alert.event,
                 resource=alert.resource
             )
-            url = "%s/#/alert/%s" % (DASHBOARD_URL, alert.id)
-            
+
+        url = "%s/#/alert/%s" % (DASHBOARD_URL, alert.id)
+
         if alert.severity == 'critical':
             color = "D8122A"
         elif alert.severity == 'major':


### PR DESCRIPTION
Otherwise custom MS_TEAMS_SUMMARY_FMT fails with UnboundLocalError: local variable 'url'
referenced before assignment.