### PR TITLE
msteams: MS_TEAMS_TEXT_FMT template

### DIFF
--- a/plugins/msteams/README.md
+++ b/plugins/msteams/README.md
@@ -49,6 +49,11 @@ this:
 MS_TEAMS_SUMMARY_FMT = '<b>[{{ alert.status|capitalize }}]</b> [{{ alert.severity|upper }}] Event {{ alert.event }} on <b>{{ alert.resource }}</b><br>{{ alert.text }}'
 ```
 
+The `MS_TEAMS_TEXT_FMT` configuration variable is a Jinja2 template
+string or filename to a template file and accepts any Jinja2 syntax.
+`MS_TEAMS_TEXT_FMT` formats `msTeamsMessage.text(alert.text)`, if omitted
+no formatting is done on `alert.text`.
+
 References
 ----------
 

--- a/plugins/msteams/setup.py
+++ b/plugins/msteams/setup.py
@@ -1,7 +1,7 @@
 
 from setuptools import setup, find_packages
 
-version = '5.0.0'
+version = '5.0.1'
 
 setup(
     name="alerta-msteams",


### PR DESCRIPTION
Add MS_TEAMS_TEXT_FMT Jinja2 template (string or file) that customizes msTeamsMessage.text(alert.text) formatting. Defaults to no formatting.