### PR TITLE
Removed # character from URL variable

### DIFF
--- a/plugins/msteams/alerta_msteams.py
+++ b/plugins/msteams/alerta_msteams.py
@@ -75,7 +75,7 @@ class SendConnectorCardMessage(PluginBase):
                 resource=alert.resource
             )
 
-        url = "%s/#/alert/%s" % (DASHBOARD_URL, alert.id)
+        url = "%s/alert/%s" % (DASHBOARD_URL, alert.id)
 
         if MS_TEAMS_TEXT_FMT:
             try:


### PR DESCRIPTION
I removed that because when you click the Alert button in Teams, your browser tries to open the url and immediately redirects the call to the Alerta homepage while removing it will send you directly to the alert details. Not a breaker but its nice for user experience.