### PR TITLE
Allow inheritance of ack timeout for alertmanager

### DIFF
--- a/plugins/prometheus/README.md
+++ b/plugins/prometheus/README.md
@@ -40,6 +40,13 @@ ALERTMANAGER_API_URL = 'http://localhost:9093'
 ALERTMANAGER_SILENCE_DAYS = 1
 ```
 
+Or, if you want to inherit silence timeout from ack timeout:
+
+```python
+ALERTMANAGER_API_URL = 'http://localhost:9093'
+ALERTMANAGER_SILENCE_FROM_ACK = True
+```
+
 **Robust Perception Demo Example**
 
 ```python


### PR DESCRIPTION
I can set custom ack timeout via Alerta API (from slack bot, for example), but Alerta not put this timeout to the Alertmanager, which is strange and not intuitive. 
I added new option `ALERTMANAGER_SILENCE_FROM_ACK` to allow timeout inheritance. By default it set to `False`, to follow the backward compatibility.