### PR TITLE
[mailer] Add SIGTERM signal handling (useful when used in Docker).

### DIFF
--- a/integrations/mailer/mailer.py
+++ b/integrations/mailer/mailer.py
@@ -6,6 +6,7 @@ import logging
 import os
 import platform
 import re
+import signal
 import smtplib
 import socket
 import sys
@@ -424,6 +425,8 @@ def parse_group_rules(config_file):
         return rules_d
     return ()
 
+def on_sigterm(x, y):
+    raise SystemExit
 
 def main():
     global OPTIONS
@@ -489,6 +492,9 @@ def main():
         group_rules = parse_group_rules(config_file)
     if group_rules is not None:
         OPTIONS['group_rules'] = group_rules
+
+    # Registering action for SIGTERM signal handling
+    signal.signal(signal.SIGTERM, on_sigterm)
 
     try:
         mailer = MailSender()


### PR DESCRIPTION
This PR allow the alerta mailer integration to exit cleanly if the SIGTERM signal is received.

This is useful when alerta-mailer is dockerized, because when stopping the container docker will send a SIGTERM signal to the process, and wait 10 seconds before killing it (which means 10 seconds delay + no clean exit if the signal is not handled by the process).
