### PR TITLE
[mailer] Do not try to send an email to no recipient (empty contacts list)

### DIFF
--- a/integrations/mailer/mailer.py
+++ b/integrations/mailer/mailer.py
@@ -468,7 +468,7 @@ def main():
             int: config.getint,
             float: config.getfloat,
             bool: config.getboolean,
-            list: lambda s, o: [e.strip() for e in config.get(s, o).split(',')] if len(config.get(s, o)) > 0 else []
+            list: lambda s, o: [e.strip() for e in config.get(s, o).split(',')] if len(config.get(s, o)) else []
         }
         for opt in DEFAULT_OPTIONS:
             # Convert the options to the expected type

--- a/integrations/mailer/mailer.py
+++ b/integrations/mailer/mailer.py
@@ -258,10 +258,7 @@ class MailSender(threading.Thread):
                             contacts.extend(new_contacts)
         
         # Don't loose time (and try to send an email) if there is no contact...
-        for contact in contacts:
-            if contact == '':
-                contacts.remove(contact)
-        if len(contacts) == 0:
+        if not contacts:
             return
 
         template_vars = {
@@ -471,7 +468,7 @@ def main():
             int: config.getint,
             float: config.getfloat,
             bool: config.getboolean,
-            list: lambda s, o: [e.strip() for e in config.get(s, o).split(',')]
+            list: lambda s, o: [e.strip() for e in config.get(s, o).split(',')] if len(config.get(s, o)) > 0 else []
         }
         for opt in DEFAULT_OPTIONS:
             # Convert the options to the expected type

--- a/integrations/mailer/mailer.py
+++ b/integrations/mailer/mailer.py
@@ -256,6 +256,13 @@ class MailSender(threading.Thread):
                                      ' adding for this rule only')
                             del contacts[:]
                             contacts.extend(new_contacts)
+        
+        # Don't loose time (and try to send an email) if there is no contact...
+        for contact in contacts:
+            if contact == '':
+                contacts.remove(contact)
+        if len(contacts) == 0:
+            return
 
         template_vars = {
             'alert': alert,


### PR DESCRIPTION
Playing with mailer, I wanted to not sending mail by default (except for rule that explicitly ask for it), and ended up unsetting the mail_to config parameter.
I found out that alerta mailer would still try to send a email, and contact the SMTP server, which ended rejecting the email because of an invalid recipient. This loose time (building the email) and resources (contacting the SMTP server etc.).

This patch will verify, after the contacts list is evaluated (depending on all rules) and check that the contacts list is not empty (discarding any empty recipient) before processing the email creation and sending.
