### PR TITLE
Add tag-based routing for slack

### DIFF
--- a/plugins/slack/README.md
+++ b/plugins/slack/README.md
@@ -48,6 +48,7 @@ ALERTA_USERNAME = '' # default alerta
 
 ```
 
+
 The `DASHBOARD_URL` setting should be configured to link Slack messages to
 the Alerta console:
 
@@ -73,6 +74,20 @@ this:
 ```python
 SLACK_SUMMARY_FMT = '*[{{ alert.status|capitalize }}]* [{{ alert.severity|capitalize }}] Event {{ alert.event }} on *{{ alert.environment }} - {{ alert.resource }}*: {{alert.value}}\n{{alert.text}}\nAlert Console: <{{ config.DASHBOARD_URL }}|click here> / Alert: <{{ config.DASHBOARD_URL }}/#/alert/{{ alert.id }}|{{ alert.id[:8] }}>'
 ```
+
+### Tag-based message routing
+
+Configuraton:
+
+```python
+from collections import OrderedDict
+
+SLACK_CHANNEL_TAG_MAP = OrderedDict({ '#application1-team': ['application=application1', 'severity=major'], '#default-alert-channel': 'default' })
+```
+
+If this parameter exists and `SLACK_CHANNEL_ENV_MAP` is not set, tag-based routing applies to the alerts. The plugin gets a set of alert tags and searches for the first occurrence in the `SLACK_CHANNEL_ENV_MAP`. If an occurrence doesn't found, `default` channel is used. If it not exist, `SLACK_CHANNEL` is used.
+
+For details, look at `test_slack.py`.
 
 Slack Payload
 -------------

--- a/plugins/slack/test_slack.py
+++ b/plugins/slack/test_slack.py
@@ -1,0 +1,56 @@
+import unittest
+import alerta_slack
+
+from collections import OrderedDict
+
+from alerta.app import create_app, custom_webhooks
+
+class ServiceIntegrationTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.routeTags = OrderedDict({
+            '#application1-major-team': ['application=application1', 'severity=major'],
+            '#application1-minor-team': ['application=application1', 'severity=minor'],
+            '#application2-major-team': ['application=application2', 'severity=major'],
+            '#application2-team': ['application=application2'],
+            '#default-alert-channel': 'default'
+        })
+
+        self.routeTagsWithoutDefault = OrderedDict({
+            '#application1-major-team': ['application=application1', 'severity=major'],
+            '#application1-minor-team': ['application=application1', 'severity=minor'],
+            '#application2-major-team': ['application=application2', 'severity=major'],
+            '#application2-team': ['application=application2']
+        })
+
+        self.routeTagsEmpty = OrderedDict()
+
+        test_config = {
+            'TESTING': True,
+            'AUTH_REQUIRED': False
+        }
+        self.app = create_app(test_config)
+        self.client = self.app.test_client()
+
+    def test_default_route(self):
+        alertTags = ['application=application3', 'severity=warning']
+        self.assertEqual(alerta_slack.route_alert_by_tag(alertTags, self.routeTags), '#default-alert-channel')
+
+        self.assertEqual(alerta_slack.route_alert_by_tag(alertTags, self.routeTagsWithoutDefault), '')
+        self.assertEqual(alerta_slack.route_alert_by_tag(alertTags, self.routeTagsWithoutDefault, 'fallback'), 'fallback')
+
+        self.assertEqual(alerta_slack.route_alert_by_tag(alertTags, self.routeTagsEmpty), '')
+        self.assertEqual(alerta_slack.route_alert_by_tag(alertTags, self.routeTagsEmpty, 'fallback'), 'fallback')
+
+    def test_route_order(self):
+        alertTags1 = ['application=application2', 'severity=warning']
+        self.assertEqual(alerta_slack.route_alert_by_tag(
+            alertTags1, self.routeTags), '#application2-team')
+
+        alertTags2 = ['application=application2']
+        self.assertEqual(alerta_slack.route_alert_by_tag(
+            alertTags2, self.routeTags), '#application2-team')
+
+        alertTags3 = ['application=application2', 'severity=major']
+        self.assertEqual(alerta_slack.route_alert_by_tag(
+            alertTags3, self.routeTags), '#application2-major-team')


### PR DESCRIPTION
Environment-based routing is ok, but not enough for some cases. For example, we have several teams (with their own slack channels) and we want to route specific alerts directly to team channels.

I implemented a simple logic based on alert tags and wrote some tests to demonstrate it. Please, take a look and feel free to add a comment.

P.S. I didn't like an `import` statement in config but have no idea how to avoid that. :(