### PR TITLE
Msteams MS_TEAMS_PAYLOAD

### DIFF
--- a/plugins/msteams/README.md
+++ b/plugins/msteams/README.md
@@ -54,6 +54,14 @@ string or filename to a template file and accepts any Jinja2 syntax.
 `MS_TEAMS_TEXT_FMT` formats `msTeamsMessage.text(alert.text)`, if omitted
 no formatting is done on `alert.text`.
 
+Teams Payload
+-------------
+With `MS_TEAMS_PAYLOAD` it's possible to fully customize the alert.
+`MS_TEAMS_PAYLOAD` is Jinja2 template (string or filename) containing the full
+HTTP POST [payload](https://docs.microsoft.com/en-us/outlook/actionable-messages/message-card-reference)(json) that's sent to `MS_TEAMS_WEBHOOK_URL`.
+
+Example payload in [example-payload.json.j2](example-payload.json.j2) file.
+
 References
 ----------
 

--- a/plugins/msteams/alerta_msteams.py
+++ b/plugins/msteams/alerta_msteams.py
@@ -18,7 +18,8 @@ except Exception as e:
     LOG.error('MS Teams: ERROR - Jinja template error: %s, template functionality will be unavailable', e)
 
 MS_TEAMS_COLORS_MAP = app.config.get('MS_TEAMS_COLORS_MAP', {})
-MS_TEAMS_DEFAULT_COLORS_MAP = {'critical': 'D8122A',
+MS_TEAMS_DEFAULT_COLORS_MAP = {'security': '000000',
+                              'critical': 'D8122A',
                               'major': 'EA680F',
                               'minor': 'FFBE1E',
                               'warning': '1E90FF'}

--- a/plugins/msteams/alerta_msteams.py
+++ b/plugins/msteams/alerta_msteams.py
@@ -23,6 +23,7 @@ MS_TEAMS_DEFAULT_COLORS_MAP = {'critical': 'D8122A',
                               'minor': 'FFBE1E',
                               'warning': '1E90FF'}
 MS_TEAMS_DEFAULT_COLOR = '00AA5A'
+MS_TEAMS_DEFAULT_TIMEOUT = 7 # pymsteams http_timeout
 
 class SendConnectorCardMessage(PluginBase):
 
@@ -104,7 +105,7 @@ class SendConnectorCardMessage(PluginBase):
         LOG.debug('MS Teams payload: %s', summary)
 
         try:
-            msTeamsMessage = pymsteams.connectorcard(MS_TEAMS_WEBHOOK_URL)
+            msTeamsMessage = pymsteams.connectorcard(hookurl=MS_TEAMS_WEBHOOK_URL, http_timeout=MS_TEAMS_DEFAULT_TIMEOUT)
             msTeamsMessage.title(summary)
             msTeamsMessage.text(text)
             msTeamsMessage.addLinkButton("Open in Alerta", url)

--- a/plugins/msteams/example-payload.json.j2
+++ b/plugins/msteams/example-payload.json.j2
@@ -1,0 +1,47 @@
+{
+  "@type": "MessageCard",
+  "@context": "https://schema.org/extensions",
+  "summary": "{{ alert.status|capitalize }} {{ alert.resource }} / {{ alert.service|join(',') }}",
+  "themeColor": "{{ color }}",
+  "title": "[{{ alert.status|capitalize }}] {{ alert.environment }} {{ alert.service|join(',') }} {{ alert.severity|upper }} - {{ alert.event }} on {{ alert.resource }}",
+  "sections": [
+    {
+      "facts": [
+        {
+          "name": "Resource:",
+           "value": "**{{ alert.resource }}**{% if alert.attributes['hostaddress'] or alert.attributes['hostaddress6'] %} ({{ alert.attributes['hostaddress'] }}{% if alert.attributes['hostaddress6'] %} / {{ alert.attributes['hostaddress6'] }}{% endif %}){% endif %}"
+        },
+        {
+          "name": "Service(s):",
+          "value": "**{{ alert.service|join(',') }}**"
+        }
+{%- if alert.origin %}
+        ,{
+           "name": "Origin:",
+           "value": "{{ alert.origin }}"
+        }{% endif %}
+      ]
+    }
+{%- if (alert.status and alert.status == 'open') and alert.text %}
+    ,{
+      "text": "```{{ alert.text }}```"
+    }{% endif %}
+  ]
+{%- if alert.status and alert.status in [ 'open', 'ack', 'assign' ] %}
+  ,"potentialAction": [
+{%- if headers and actions %}
+{%- for act in actions %}
+    {
+      "@type": "{{ act['type'] }}",
+      "name": "{{ act['name'] }}",
+      "target": "{{ act['target'] }}",
+      "headers": {{ headers }},
+      "body": {{ act['body'] }}
+    },{% endfor %}{% endif %}
+    {
+      "@type": "OpenUri",
+      "name": "View in Alerta",
+      "targets": [ { "os": "default", "uri": "{{ url }}" } ]
+    }
+  ]{% endif %}
+}

--- a/plugins/msteams/setup.py
+++ b/plugins/msteams/setup.py
@@ -1,7 +1,7 @@
 
 from setuptools import setup, find_packages
 
-version = '5.1.1'
+version = '5.2.0'
 
 setup(
     name="alerta-msteams",


### PR DESCRIPTION
Few commits to prepare for msteams webhook. These commits add MS_TEAMS_PAYLOAD that allows to fully customize the http POST json payload (this is similar to SLACK_PAYLOAD). pymsteams or requests.post timeout is set to MS_TEAMS_DEFAULT_TIMEOUT (7s) instead of the default pymsteams default 60s.


Question on naming msteams webhook: I tried to use webhooks/msteams/alerta_msteams.py for teams webhook, but I assume this conflicts with plugins/msteams ? When I renamed the webhook to webhooks/msteamswebhook/alerta_msteamswebhook.py it loads. What's the recommened way for naming webhooks ?