### PR TITLE
Fix boolean env variable

### DIFF
--- a/plugins/amqp/alerta_amqp.py
+++ b/plugins/amqp/alerta_amqp.py
@@ -19,7 +19,11 @@ DEFAULT_AMQP_SEND_ALERT_HISTORY = True
 
 AMQP_URL = os.environ.get('REDIS_URL') or os.environ.get('AMQP_URL') or app.config.get('AMQP_URL', DEFAULT_AMQP_URL)
 AMQP_TOPIC = os.environ.get('AMQP_TOPIC') or app.config.get('AMQP_TOPIC', DEFAULT_AMQP_TOPIC)
-AMQP_SEND_ALERT_HISTORY = os.environ.get('AMQP_SEND_ALERT_HISTORY') or app.config.get('AMQP_SEND_ALERT_HISTORY', DEFAULT_AMQP_SEND_ALERT_HISTORY)
+
+if "AMQP_SEND_ALERT_HISTORY" in os.environ:
+    AMQP_SEND_ALERT_HISTORY = False if os.environ.get("AMQP_SEND_ALERT_HISTORY") == "False" else True
+else:
+    AMQP_SEND_ALERT_HISTORY = app.config.get('AMQP_SEND_ALERT_HISTORY', DEFAULT_AMQP_SEND_ALERT_HISTORY)
 
 
 class FanoutPublisher(PluginBase):

--- a/plugins/amqp/alerta_amqp.py
+++ b/plugins/amqp/alerta_amqp.py
@@ -20,11 +20,6 @@ DEFAULT_AMQP_SEND_ALERT_HISTORY = True
 AMQP_URL = os.environ.get('REDIS_URL') or os.environ.get('AMQP_URL') or app.config.get('AMQP_URL', DEFAULT_AMQP_URL)
 AMQP_TOPIC = os.environ.get('AMQP_TOPIC') or app.config.get('AMQP_TOPIC', DEFAULT_AMQP_TOPIC)
 
-if "AMQP_SEND_ALERT_HISTORY" in os.environ:
-    AMQP_SEND_ALERT_HISTORY = False if os.environ.get("AMQP_SEND_ALERT_HISTORY") == "False" else True
-else:
-    AMQP_SEND_ALERT_HISTORY = app.config.get('AMQP_SEND_ALERT_HISTORY', DEFAULT_AMQP_SEND_ALERT_HISTORY)
-
 
 class FanoutPublisher(PluginBase):
 
@@ -49,14 +44,14 @@ class FanoutPublisher(PluginBase):
 
         LOG.info('Configured fanout publisher on topic "%s"', AMQP_TOPIC)
 
-    def pre_receive(self, alert):
+    def pre_receive(self, alert, **kwargs):
         return alert
 
-    def post_receive(self, alert):
+    def post_receive(self, alert, **kwargs):
         LOG.info('Sending message %s to AMQP topic "%s"', alert.get_id(), AMQP_TOPIC)
-        body = alert.get_body(history=AMQP_SEND_ALERT_HISTORY)
+        body = alert.get_body(history=self.get_config('AMQP_SEND_ALERT_HISTORY', default=DEFAULT_AMQP_SEND_ALERT_HISTORY, type=bool, **kwargs))
         LOG.debug('Message: %s', body)
         self.producer.publish(body, declare=[self.exchange], retry=True)
 
-    def status_change(self, alert, status, text):
+    def status_change(self, alert, status, text, **kwargs):
         return


### PR DESCRIPTION
I found out that my previous PR was wrong when handling the boolean parameter from environment variable.

os.environ.get('AMQP_SEND_ALERT_HISTORY') will always return a string if defined, so code like :
AMQP_SEND_ALERT_HISTORY = os.environ.get('AMQP_SEND_ALERT_HISTORY') or app.config.get('AMQP_SEND_ALERT_HISTORY', DEFAULT_AMQP_SEND_ALERT_HISTORY) 
would end with AMQP_SEND_ALERT_HISTORY="True" or "False" if the env variable is defined.
So depending on how code is using it, it would not work as expected (in AMQP plugin case, the test to keep the history in the alert would always keep the history, whatever value was set in the env variable, because the final evaluated code is `if not history: history = []`.

This PR will ensure that AMQP_SEND_ALERT_HISTORY is treated as boolean when passed as an env variable, by the use the get_config logic proposed by the PluginBase model.

I noticed that several other plugins were handling boolean env variable in the same wrong way, so I am pretty sure that some plugins are broken in some specific cases (SLACK_SEND_ON_ACK in the slack plugin, ALERTMANAGER_SILENCE_FROM_ACK in the prometheus plugin, and potentially others).