### PR TITLE
slack: Choose a channel based on severity or event

### DIFF
--- a/plugins/slack/README.md
+++ b/plugins/slack/README.md
@@ -42,6 +42,8 @@ SLACK_WEBHOOK_URL = 'https://hooks.slack.com/services/T00000000/B00000000/XXXXXX
 SLACK_ATTACHMENTS = True  # default=False
 SLACK_CHANNEL = '' # if empty then uses channel from incoming webhook configuration
 SLACK_CHANNEL_ENV_MAP = { 'Production' : '#alert-prod' } # Default=None (optionnal) Allow to specify a channel on a per-environment basis. SLACK_CHANNEL is used a default value
+SLACK_CHANNEL_EVENT_MAP = { 'Node offline' : '#critical-alerts' } # Default=None (optionnal) Allow to specify a channel on a per-event basis. SLACK_CHANNEL is used a default value
+SLACK_CHANNEL_SEVERITY_MAP = { 'crtical' : '#critical-alerts', 'informational': '#noisy-feed' } # Default=None (optionnal) Allow to specify a channel on a per-severity basis. SLACK_CHANNEL is used a default value
 
 ICON_EMOJI = '' # default :rocket:
 ALERTA_USERNAME = '' # default alerta

--- a/plugins/slack/alerta_slack.py
+++ b/plugins/slack/alerta_slack.py
@@ -26,6 +26,18 @@ try:
         os.environ.get('SLACK_CHANNEL_ENV_MAP'))
 except Exception as e:
     SLACK_CHANNEL_ENV_MAP = app.config.get('SLACK_CHANNEL_ENV_MAP', dict())
+
+try:
+    SLACK_CHANNEL_EVENT_MAP = json.loads(
+        os.environ.get('SLACK_CHANNEL_EVENT_MAP'))
+except Exception as e:
+    SLACK_CHANNEL_EVENT_MAP = app.config.get('SLACK_CHANNEL_EVENT_MAP', dict())
+
+try:
+    SLACK_CHANNEL_SEVERITY_MAP = json.loads(
+        os.environ.get('SLACK_CHANNEL_SEVERITY_MAP'))
+except Exception as e:
+    SLACK_CHANNEL_SEVERITY_MAP = app.config.get('SLACK_CHANNEL_SEVERITY_MAP', dict())
     
 SLACK_SEND_ON_ACK = os.environ.get(
     'SLACK_SEND_ON_ACK') or app.config.get('SLACK_SEND_ON_ACK', False)
@@ -87,7 +99,22 @@ class ServiceIntegration(PluginBase):
             color = self._severities[alert.severity]
         else:
             color = '#00CC00'  # green
-        channel = SLACK_CHANNEL_ENV_MAP.get(alert.environment, SLACK_CHANNEL)
+        channel = SLACK_CHANNEL_SEVERITY_MAP.get(alert.severity, SLACK_CHANNEL)
+        if SLACK_CHANNEL_SEVERITY_MAP.get(alert.severity):
+            LOG.debug("Found severity mapping. Channel: %s" % channel)
+        else:
+            LOG.debug("No severity mapping. Channel: %s" % channel)
+        channel = SLACK_CHANNEL_ENV_MAP.get(alert.environment, channel)
+        if SLACK_CHANNEL_ENV_MAP.get(alert.environment):
+            LOG.debug("Found env mapping. Channel: %s" % channel)
+        else:
+            LOG.debug("No env mapping. Channel: %s" % channel)
+        channel = SLACK_CHANNEL_EVENT_MAP.get(alert.event, channel)
+        if SLACK_CHANNEL_EVENT_MAP.get(alert.event):
+            LOG.debug("Found event mapping. Channel: %s" % channel)
+        else:
+            LOG.debug("No event mapping. Channel: %s" % channel)
+
         templateVars = {
             'alert': alert,
             'status': status if status else alert.status,

--- a/plugins/slack/setup.py
+++ b/plugins/slack/setup.py
@@ -1,7 +1,7 @@
 
 from setuptools import setup, find_packages
 
-version = '5.5.0'
+version = '5.5.1'
 
 setup(
     name="alerta-slack",


### PR DESCRIPTION
This PR adds 2 new env variables/config to override slack channel on a per event or per severity basis.

The env variable / config are called `SLACK_CHANNEL_EVENT_MAP` and `SLACK_CHANNEL_SEVERITY_MAP` (to match the existing `SLACK_CHANNEL_ENV_MAP`)