### PR TITLE
plugin/alerta-prometheus: fix 500 error when response is not as expected

### DIFF
--- a/plugins/prometheus/alerta_prometheus.py
+++ b/plugins/prometheus/alerta_prometheus.py
@@ -91,7 +91,7 @@ class AlertmanagerSilence(PluginBase):
             # example r={"status":"success","data":{"silenceId":8}}
             try:
                 data = r.json().get('data', [])
-                if len(data) > 0:
+                if data:
                   silenceId = data['silenceId']
                   alert.attributes['silenceId'] = silenceId
                 else:

--- a/plugins/prometheus/alerta_prometheus.py
+++ b/plugins/prometheus/alerta_prometheus.py
@@ -90,8 +90,12 @@ class AlertmanagerSilence(PluginBase):
 
             # example r={"status":"success","data":{"silenceId":8}}
             try:
-                silenceId = r.json()['data']['silenceId']
-                alert.attributes['silenceId'] = silenceId
+                data = r.json().get('data', [])
+                if len(data) > 0:
+                  silenceId = data['silenceId']
+                  alert.attributes['silenceId'] = silenceId
+                else:
+                  silenceId = alert.attributes.get('silenceId', "unknown")
                 text = text + ' (silenced in Alertmanager)'
             except Exception as e:
                 raise RuntimeError("Alertmanager: ERROR - %s" % e)


### PR DESCRIPTION
Alertmanager Api may respond with empty set of silenceIds, which may cause exception

"alerta.exceptions.ApiError: Alertmanager: ERROR - list indices must
 be integers or slices, not str"

This error is seen from the client, and the Alert can not be ACK-ed