### PR TITLE
add SLACK_CHANNEL_MAP for environment and severity mapping

### DIFF
--- a/plugins/slack/README.md
+++ b/plugins/slack/README.md
@@ -46,7 +46,7 @@ SLACK_CHANNEL_EVENT_MAP = { 'Node offline' : '#critical-alerts' } # Default=None
 SLACK_CHANNEL_SEVERITY_MAP = { 'critical' : '#critical-alerts', 'informational': '#noisy-feed' } # Default=None (optional) Allow specifying a channel on a per-severity basis. SLACK_CHANNEL is used as a default value.
 SLACK_CHANNEL_MAP = { 'Production' : { 'critical' : '#prod-alerts' } } # Default=None (optional) Allow specifying a channel on both a per-environment and per-severity basis. SLACK_CHANNEL is used as a default value.
 
-ICON_EMOJI = '' # default :rocket:
+ICON_EMOJI = '' # default None
 ALERTA_USERNAME = '' # default alerta
 
 ```

--- a/plugins/slack/README.md
+++ b/plugins/slack/README.md
@@ -41,9 +41,10 @@ for your Slack channel and adding the following configuration settings to `alert
 SLACK_WEBHOOK_URL = 'https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX'
 SLACK_ATTACHMENTS = True  # default=False
 SLACK_CHANNEL = '' # if empty then uses channel from incoming webhook configuration
-SLACK_CHANNEL_ENV_MAP = { 'Production' : '#alert-prod' } # Default=None (optionnal) Allow to specify a channel on a per-environment basis. SLACK_CHANNEL is used a default value
-SLACK_CHANNEL_EVENT_MAP = { 'Node offline' : '#critical-alerts' } # Default=None (optionnal) Allow to specify a channel on a per-event basis. SLACK_CHANNEL is used a default value
-SLACK_CHANNEL_SEVERITY_MAP = { 'crtical' : '#critical-alerts', 'informational': '#noisy-feed' } # Default=None (optionnal) Allow to specify a channel on a per-severity basis. SLACK_CHANNEL is used a default value
+SLACK_CHANNEL_ENV_MAP = { 'Production' : '#alert-prod' } # Default=None (optional) Allow specifying a channel on a per-environment basis. SLACK_CHANNEL is used as a default value.
+SLACK_CHANNEL_EVENT_MAP = { 'Node offline' : '#critical-alerts' } # Default=None (optional) Allow specifying a channel on a per-event basis. SLACK_CHANNEL is used as a default value.
+SLACK_CHANNEL_SEVERITY_MAP = { 'critical' : '#critical-alerts', 'informational': '#noisy-feed' } # Default=None (optional) Allow specifying a channel on a per-severity basis. SLACK_CHANNEL is used as a default value.
+SLACK_CHANNEL_MAP = { 'Production' : { 'critical' : '#prod-alerts' } } # Default=None (optional) Allow specifying a channel on both a per-environment and per-severity basis. SLACK_CHANNEL is used as a default value.
 
 ICON_EMOJI = '' # default :rocket:
 ALERTA_USERNAME = '' # default alerta

--- a/plugins/slack/alerta_slack.py
+++ b/plugins/slack/alerta_slack.py
@@ -40,6 +40,12 @@ try:
         os.environ.get('SLACK_CHANNEL_SEVERITY_MAP'))
 except Exception as e:
     SLACK_CHANNEL_SEVERITY_MAP = app.config.get('SLACK_CHANNEL_SEVERITY_MAP', dict())
+
+try:
+    SLACK_CHANNEL_MAP = json.loads(
+        os.environ.get('SLACK_CHANNEL_MAP'))
+except Exception as e:
+    SLACK_CHANNEL_MAP = app.config.get('SLACK_CHANNEL_MAP', dict())
     
 SLACK_SEND_ON_ACK = os.environ.get(
     'SLACK_SEND_ON_ACK') or app.config.get('SLACK_SEND_ON_ACK', False)
@@ -117,6 +123,11 @@ class ServiceIntegration(PluginBase):
             LOG.debug("Found event mapping. Channel: %s" % channel)
         else:
             LOG.debug("No event mapping. Channel: %s" % channel)
+        channel = SLACK_CHANNEL_MAP.get(alert.environment, dict()).get(alert.severity, channel)
+        if SLACK_CHANNEL_MAP.get(alert.environment, dict()).get(alert.severity, channel):
+            LOG.debug("Found env-severity mapping. Channel: %s" % channel)
+        else:
+            LOG.debug("No env-severity mapping. Channel: %s" % channel)
 
         templateVars = {
             'alert': alert,

--- a/plugins/slack/alerta_slack.py
+++ b/plugins/slack/alerta_slack.py
@@ -91,7 +91,7 @@ class ServiceIntegration(PluginBase):
         SLACK_CHANNEL = self.get_config('SLACK_CHANNEL', default='', type=str, **kwargs)
         SLACK_SUMMARY_FMT = self.get_config('SLACK_SUMMARY_FMT', type=str, **kwargs)  # Message summary format
         SLACK_PAYLOAD = self.get_config('SLACK_PAYLOAD', type=str, **kwargs)  # Full API control
-        ICON_EMOJI = self.get_config('ICON_EMOJI', default=':rocket:', type=str, **kwargs)
+        ICON_EMOJI = self.get_config('ICON_EMOJI', type=str, **kwargs)
         ALERTA_USERNAME = self.get_config('ALERTA_USERNAME', default='alerta', type=str, **kwargs)
         DASHBOARD_URL = self.get_config('DASHBOARD_URL', default='', type=str, **kwargs)
         SLACK_TOKEN = self.get_config('SLACK_TOKEN', type=str, **kwargs)
@@ -147,33 +147,26 @@ class ServiceIntegration(PluginBase):
                     short_id=alert.get_id(short=True),
                     dashboard=DASHBOARD_URL
                 )
-            if not SLACK_ATTACHMENTS:
-                payload = {
-                    "username": ALERTA_USERNAME,
-                    "channel": channel,
-                    "text": summary,
-                    "icon_emoji": ICON_EMOJI
-                }
-            else:
-                payload = {
-                    "username": ALERTA_USERNAME,
-                    "channel": channel,
-                    "icon_emoji": ICON_EMOJI,
-                    "text": summary,
-                    "attachments": [{
-                        "fallback": summary,
-                        "color": color,
-                        "fields": [
-                            {"title": "Status", "value": (status if status else alert.status).capitalize(),
-                             "short": True},
-                            {"title": "Environment",
-                                "value": alert.environment, "short": True},
-                            {"title": "Resource", "value": alert.resource, "short": True},
-                            {"title": "Services", "value": ", ".join(
-                                alert.service), "short": True}
-                        ]
-                    }]
-                }
+            payload = {}
+            payload.username = ALERTA_USERNAME
+            payload.channel = channel
+            payload.text = summary
+            if ICON_EMOJI:
+                payload.icon_emoji = ICON_EMOJI
+            if SLACK_ATTACHMENTS:
+                payload.attachments = [{
+                    "fallback": summary,
+                    "color": color,
+                    "fields": [
+                        {"title": "Status", "value": (status if status else alert.status).capitalize(),
+                            "short": True},
+                        {"title": "Environment",
+                            "value": alert.environment, "short": True},
+                        {"title": "Resource", "value": alert.resource, "short": True},
+                        {"title": "Services", "value": ", ".join(
+                            alert.service), "short": True}
+                    ]
+                }]
 
         return payload
 

--- a/plugins/slack/alerta_slack.py
+++ b/plugins/slack/alerta_slack.py
@@ -159,13 +159,13 @@ class ServiceIntegration(PluginBase):
                     dashboard=DASHBOARD_URL
                 )
             payload = {}
-            payload.username = ALERTA_USERNAME
-            payload.channel = channel
-            payload.text = summary
+            payload['username'] = ALERTA_USERNAME
+            payload['channel'] = channel
+            payload['text'] = summary
             if ICON_EMOJI:
-                payload.icon_emoji = ICON_EMOJI
+                payload['icon_emoji'] = ICON_EMOJI
             if SLACK_ATTACHMENTS:
-                payload.attachments = [{
+                payload['attachments'] = [{
                     "fallback": summary,
                     "color": color,
                     "fields": [

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,7 +7,7 @@ mock
 mypy
 pre-commit
 pylint
-pytest
+pytest>=5.4.3
 pytest-cov
 python-dotenv
 requests_mock


### PR DESCRIPTION
Because I wanted to make the general-purpose `#alerts` channel on Slack only receive important production alerts, I needed a way to be able to choose which channel an alert goes to based on environment _and_ severity.

In the process, I cleaned up the payload code a little bit and made `ICON_EMOJI` optional. Now you can upload a custom avatar for your webhook and it'll display as long as `ICON_EMOJI` isn't set.