### PR TITLE
SLACK_SEVERITY_FILTER allows pre-filtering of alerts sent to Slack solely by severity

### DIFF
--- a/plugins/slack/README.md
+++ b/plugins/slack/README.md
@@ -44,7 +44,7 @@ SLACK_CHANNEL = '' # if empty then uses channel from incoming webhook configurat
 SLACK_CHANNEL_ENV_MAP = { 'Production' : '#alert-prod' } # Default=None (optionnal) Allow to specify a channel on a per-environment basis. SLACK_CHANNEL is used a default value
 SLACK_CHANNEL_EVENT_MAP = { 'Node offline' : '#critical-alerts' } # Default=None (optionnal) Allow to specify a channel on a per-event basis. SLACK_CHANNEL is used a default value
 SLACK_CHANNEL_SEVERITY_MAP = { 'critical' : '#critical-alerts', 'informational': '#noisy-feed' } # Default=None (optionnal) Allow to specify a channel on a per-severity basis. SLACK_CHANNEL is used a default value
-SLACK_SEVERITY_FILTER = ['critical', 'major'] # 
+SLACK_SEVERITY_FILTER = ['critical', 'major'] # only alerts with severity in this list will be forwarded to Slack
 ICON_EMOJI = '' # default :rocket:
 ALERTA_USERNAME = '' # default alerta
 

--- a/plugins/slack/README.md
+++ b/plugins/slack/README.md
@@ -44,7 +44,7 @@ SLACK_CHANNEL = '' # if empty then uses channel from incoming webhook configurat
 SLACK_CHANNEL_ENV_MAP = { 'Production' : '#alert-prod' } # Default=None (optionnal) Allow to specify a channel on a per-environment basis. SLACK_CHANNEL is used a default value
 SLACK_CHANNEL_EVENT_MAP = { 'Node offline' : '#critical-alerts' } # Default=None (optionnal) Allow to specify a channel on a per-event basis. SLACK_CHANNEL is used a default value
 SLACK_CHANNEL_SEVERITY_MAP = { 'critical' : '#critical-alerts', 'informational': '#noisy-feed' } # Default=None (optionnal) Allow to specify a channel on a per-severity basis. SLACK_CHANNEL is used a default value
-SLACK_SEVERITY_FILTER = ['critical', 'major'] # only alerts with severity in this list will be forwarded to Slack
+SLACK_SEVERITY_FILTER = ['warning'] # blocks alerts with severity in this list from being forwarded to Slack
 ICON_EMOJI = '' # default :rocket:
 ALERTA_USERNAME = '' # default alerta
 

--- a/plugins/slack/README.md
+++ b/plugins/slack/README.md
@@ -43,8 +43,8 @@ SLACK_ATTACHMENTS = True  # default=False
 SLACK_CHANNEL = '' # if empty then uses channel from incoming webhook configuration
 SLACK_CHANNEL_ENV_MAP = { 'Production' : '#alert-prod' } # Default=None (optionnal) Allow to specify a channel on a per-environment basis. SLACK_CHANNEL is used a default value
 SLACK_CHANNEL_EVENT_MAP = { 'Node offline' : '#critical-alerts' } # Default=None (optionnal) Allow to specify a channel on a per-event basis. SLACK_CHANNEL is used a default value
-SLACK_CHANNEL_SEVERITY_MAP = { 'crtical' : '#critical-alerts', 'informational': '#noisy-feed' } # Default=None (optionnal) Allow to specify a channel on a per-severity basis. SLACK_CHANNEL is used a default value
-
+SLACK_CHANNEL_SEVERITY_MAP = { 'critical' : '#critical-alerts', 'informational': '#noisy-feed' } # Default=None (optionnal) Allow to specify a channel on a per-severity basis. SLACK_CHANNEL is used a default value
+SLACK_SEVERITY_FILTER = ['critical', 'major'] # 
 ICON_EMOJI = '' # default :rocket:
 ALERTA_USERNAME = '' # default alerta
 

--- a/plugins/slack/alerta_slack.py
+++ b/plugins/slack/alerta_slack.py
@@ -191,7 +191,7 @@ class ServiceIntegration(PluginBase):
             return
 
         if alert.severity not in SLACK_SEVERITY_FILTER:
-            LOG.debug("Alert severity %s is not included in SLACK_SEVERITY_FILTER, thus it will not be forwarded to Slack. %s" % alert.severity)
+            LOG.debug("Alert severity %s is not included in SLACK_SEVERITY_FILTER list, thus it will not be forwarded to Slack." % alert.severity)
             return
 
         try:

--- a/plugins/slack/alerta_slack.py
+++ b/plugins/slack/alerta_slack.py
@@ -190,8 +190,8 @@ class ServiceIntegration(PluginBase):
         if alert.repeat:
             return
 
-        if alert.severity not in SLACK_SEVERITY_FILTER:
-            LOG.debug("Alert severity %s is not included in SLACK_SEVERITY_FILTER list, thus it will not be forwarded to Slack." % alert.severity)
+        if alert.severity in SLACK_SEVERITY_FILTER:
+            LOG.debug("Alert severity %s is included in SLACK_SEVERITY_FILTER list, thus it will not be forwarded to Slack." % alert.severity)
             return
 
         try:

--- a/plugins/slack/alerta_slack.py
+++ b/plugins/slack/alerta_slack.py
@@ -4,6 +4,7 @@ import logging
 import os
 import requests
 import traceback
+import ast
 
 LOG = logging.getLogger('alerta.plugins.slack')
 
@@ -42,7 +43,7 @@ except Exception as e:
     SLACK_CHANNEL_SEVERITY_MAP = app.config.get('SLACK_CHANNEL_SEVERITY_MAP', dict())
 
 try:
-    SLACK_SEVERITY_FILTER = json.loads(
+    SLACK_SEVERITY_FILTER = ast.literal_eval(
         os.environ.get('SLACK_SEVERITY_FILTER'))
 except Exception as e:
     SLACK_SEVERITY_FILTER = app.config.get('SLACK_SEVERITY_FILTER', list())


### PR DESCRIPTION
Adds configuration setting SLACK_SEVERITY_FILTER (list) in alertad.conf to allow filtering of alerts to be forwarded to Slack based upon their severity.  For example, if `SLACK_SEVERITY_FILTER = ['warning']`, all alerts with 'warning' severity will NOT get processed or filtered by the other rules in the config file.  Alerts of any other severity will pass through this filter.

I found this useful because we use the Alerta UI as well as Slack, where we only want to get Slack notifications for the more serious stuff that requires immediate attention (severity levels of 'major' or 'critical'), and we leave it to our admin staff to look at the UI panel regularly to deal with less urgent lower level alerts.