### PR TITLE
Update to work with later version of pubsub

### DIFF
--- a/plugins/pubsub/README.md
+++ b/plugins/pubsub/README.md
@@ -12,6 +12,9 @@ You need to install following python packages:
 
     $ sudo pip install --upgrade google-cloud
     $ sudo pip install --upgrade oauth2client
+    $ sudo pip install grpcio==1.30.0
+
+There are issues running never versions of grpcio (Confirmed stable and working with grpcio 1.30.0). 
 
 Follow this to configure [authentication](https://googlecloudplatform.github.io/google-cloud-python/stable/pubsub-usage.html#authentication-configuration)
 
@@ -53,3 +56,4 @@ License
 -------
 
 Copyright (c) 2017 Arindam Choudhury. Available under the MIT License.
+Copyright (c) 2021 Lasse Hjorth. Available under the MIT License.

--- a/plugins/pubsub/alerta_pubsub.py
+++ b/plugins/pubsub/alerta_pubsub.py
@@ -2,6 +2,7 @@ import os
 import logging
 import base64
 import json
+from datetime import datetime
 
 try:
     from alerta.plugins import app  # alerta >= 5.0
@@ -10,7 +11,7 @@ except ImportError:
 
 from alerta.plugins import PluginBase
 
-from google.cloud import pubsub
+from google.cloud import pubsub_v1
 from google.oauth2 import service_account
 
 LOG = logging.getLogger('alerta.plugins.pubsub')
@@ -36,23 +37,41 @@ class SendToPubsub(PluginBase):
             LOG.info('using service account JSON : %s', json_dict)
             credential =  service_account.Credentials.from_service_account_info(json_dict)
             scoped_credential = credential.with_scopes(PUBSUB_SCOPES)
-            return pubsub.PublisherClient(credentials=scoped_credential)
+            return pubsub_v1.PublisherClient(credentials=scoped_credential)
 
         LOG.info('default')
-        return pubsub.PublisherClient()
+        return pubsub_v1.PublisherClient()
 
     def pre_receive(self, alert):
         return alert
 
     def post_receive(self, alert):
-        body = alert.get_body()
-        try:
-            encoded_message = base64.b64encode(json.dumps(body))
-            future = self.publisher.publish(self.topic, str(encoded_message))
-            future.result()
-        except Exception as excp:
-            LOG.exception(excp)
-            raise RuntimeError("pubsub exception: %s - %s" % (excp, body))
+        body = alert.get_body(history=False)
+        if not alert.severity in ['cleared', 'normal', 'ok']:
+            try:
+                encoded_message = json.dumps(body)
+                encoded_message = encoded_message.encode("utf-8")
+                LOG.info("post receive")
+                LOG.info(encoded_message)
+                future = self.publisher.publish(self.topic, encoded_message)
+                future.result()
+            except Exception as excp:
+                LOG.exception(excp)
+                raise RuntimeError("pubsub exception: %s - %s" % (excp, body))
 
     def status_change(self, alert, status, text):
-        return
+        body = alert.get_body(history=False)
+        if not alert.severity in ['normal','ok']:
+            try:
+                body['status'] = status
+                body['updateTime'] = datetime.utcnow().isoformat()
+                encoded_message = json.dumps(body)
+                encoded_message = encoded_message.encode("utf-8")
+                LOG.info("status change: %s", status)
+                LOG.info(encoded_message)
+                future = self.publisher.publish(self.topic, encoded_message)
+                future.result()
+            except Exception as excp:
+                LOG.exception(excp)
+                raise RuntimeError("pubsub exception: %s - %s" % (excp, body))
+

--- a/plugins/pubsub/setup.py
+++ b/plugins/pubsub/setup.py
@@ -15,7 +15,8 @@ setup(
     py_modules=['alerta_pubsub'],
     install_requires=[
         'google-cloud-pubsub',
-        'oauth2client'
+        'oauth2client',
+        'grpcio==1.30.0'
     ],
     include_package_data=True,
     zip_safe=True,


### PR DESCRIPTION
Update verion of pubsub plugin.

Works with never version of google  python modules.

Behavior has changed a bit - the use case behind this, is using the service to generate an audit trail of alerts. 