### PR TITLE
mailer: Fix checking multiple fields.

### DIFF
--- a/integrations/mailer/mailer.py
+++ b/integrations/mailer/mailer.py
@@ -245,6 +245,7 @@ class MailSender(threading.Thread):
                     if self._rule_matches(field['regex'], value):
                         is_matching = True
                     else:
+                        is_matching = False
                         break
                 if is_matching:
                     # Add up any new contacts


### PR DESCRIPTION
According to the documentation, if multiple fields are defined, they
must all match in order to send an email.