### PR TITLE
Zabbix plugin: None type cannot be used in a join() function

### DIFF
--- a/plugins/zabbix/alerta_zabbix.py
+++ b/plugins/zabbix/alerta_zabbix.py
@@ -62,7 +62,8 @@ class ZabbixEventAck(PluginBase):
                 r = self.zapi.event.get(objectids=trigger_id, acknowledged=False, output='extend', sortfield='clock', sortorder='DESC', limit=10)
                 event_ids = [e['eventid'] for e in r]
             except ZabbixAPIException:
-                event_ids = None
+                LOG.error(f"No eventids retrieved from Zabbix for {trigger_id}")
+                return
 
             LOG.debug('Zabbix: status=ack; triggerId %s => eventIds %s', trigger_id, ','.join(event_ids))
 
@@ -87,7 +88,8 @@ class ZabbixEventAck(PluginBase):
                 r = self.zapi.event.get(objectids=trigger_id, output='extend', sortfield='clock', sortorder='DESC', limit=10)
                 event_ids = [e['eventid'] for e in r]
             except ZabbixAPIException:
-                event_ids = None
+                LOG.error(f"No eventids retrieved from Zabbix for {trigger_id}")
+                return
 
             LOG.debug('Zabbix: status=closed; triggerId %s => eventIds %s', trigger_id, ','.join(event_ids))
 


### PR DESCRIPTION
Occasionally, Zabbix will return bad data from API requests, this can actually cause stacktraces in Alerta:
```
May 28 14:43:41 use1-alertmanager-stg-1 alertad[552191]: 2021-05-28 14:43:41,193 alerta.app[552218]: [ERROR] can only join an iterable request_id=d555dfc4-f2f5-4782-926a-133a3ba6cf29 ip=10.40.240.16
                                                         Traceback (most recent call last):
                                                           File "/datto/monitoring/alerta/.pyenv/versions/3.9.1/lib/python3.9/site-packages/alerta/utils/api.py", line 168, in process_status
                                                             updated = plugin.status_change(alert, status, text, config=wanted_config)
                                                         TypeError: status_change() got an unexpected keyword argument 'config'
                                                         
                                                         During handling of the above exception, another exception occurred:
                                                         
                                                         Traceback (most recent call last):
                                                           File "/datto/monitoring/alerta/.pyenv/versions/3.9.1/lib/python3.9/site-packages/alerta/utils/hooks.py", line 38, in process_status_change
                                                             alert, status, text = process_status(alert, status, text)
                                                           File "/datto/monitoring/alerta/.pyenv/versions/3.9.1/lib/python3.9/site-packages/alerta/utils/api.py", line 170, in process_status
                                                             updated = plugin.status_change(alert, status, text)  # for backward compatibility
                                                           File "/datto/monitoring/alerta/.pyenv/versions/3.9.1/lib/python3.9/site-packages/alerta_zabbix.py", line 110, in status_change
                                                             LOG.debug('Zabbix: status=closed; triggerId %s => eventIds %s', trigger_id, ','.join(event_ids))
                                                         TypeError: can only join an iterable
                                                         
                                                         During handling of the above exception, another exception occurred:
                                                         
                                                         Traceback (most recent call last):
                                                           File "/datto/monitoring/alerta/.pyenv/versions/3.9.1/lib/python3.9/site-packages/alerta/utils/api.py", line 61, in process_alert
                                                             alert = alert.update(is_correlated)
                                                           File "/datto/monitoring/alerta/.pyenv/versions/3.9.1/lib/python3.9/site-packages/alerta/models/alert.py", line 346, in update
                                                             r = status_change_hook.send(correlate_with, status=new_status, text=self.text)
                                                           File "/datto/monitoring/alerta/.pyenv/versions/3.9.1/lib/python3.9/site-packages/blinker/base.py", line 266, in send
                                                             return [(receiver, receiver(sender, **kwargs))
                                                           File "/datto/monitoring/alerta/.pyenv/versions/3.9.1/lib/python3.9/site-packages/blinker/base.py", line 266, in <listcomp>
                                                             return [(receiver, receiver(sender, **kwargs))
                                                           File "/datto/monitoring/alerta/.pyenv/versions/3.9.1/lib/python3.9/site-packages/alerta/utils/hooks.py", line 42, in process_status_change
                                                             raise ApiError(str(e), 500)
                                                         alerta.exceptions.ApiError: can only join an iterable
                                                         
                                                         During handling of the above exception, another exception occurred:
                                                         
                                                         Traceback (most recent call last):
                                                           File "/datto/monitoring/alerta/.pyenv/versions/3.9.1/lib/python3.9/site-packages/alerta/views/alerts.py", line 53, in receive
                                                             alert = process_alert(alert)
                                                           File "/datto/monitoring/alerta/.pyenv/versions/3.9.1/lib/python3.9/site-packages/alerta/utils/api.py", line 65, in process_alert
                                                             raise ApiError(str(e))
                                                         alerta.exceptions.ApiError: can only join an iterable
                                                         
                                                         During handling of the above exception, another exception occurred:
                                                         
                                                         Traceback (most recent call last):
                                                           File "/datto/monitoring/alerta/.pyenv/versions/3.9.1/lib/python3.9/site-packages/flask/app.py", line 1950, in full_dispatch_request
                                                             rv = self.dispatch_request()
                                                           File "/datto/monitoring/alerta/.pyenv/versions/3.9.1/lib/python3.9/site-packages/flask/app.py", line 1936, in dispatch_request
                                                             return self.view_functions[rule.endpoint](**req.view_args)
                                                           File "/datto/monitoring/alerta/.pyenv/versions/3.9.1/lib/python3.9/site-packages/flask_cors/decorator.py", line 128, in wrapped_function
                                                             resp = make_response(f(*args, **kwargs))
                                                           File "/datto/monitoring/alerta/.pyenv/versions/3.9.1/lib/python3.9/site-packages/alerta/auth/decorators.py", line 53, in wrapped
                                                             return f(*args, **kwargs)
                                                           File "/datto/monitoring/alerta/.pyenv/versions/3.9.1/lib/python3.9/site-packages/alerta/models/metrics.py", line 258, in wrapped
                                                             response = f(*args, **kwargs)
                                                           File "/datto/monitoring/alerta/.pyenv/versions/3.9.1/lib/python3.9/site-packages/alerta/utils/response.py", line 18, in decorated
                                                             return func(*args, **kwargs)
                                                           File "/datto/monitoring/alerta/.pyenv/versions/3.9.1/lib/python3.9/site-packages/alerta/views/alerts.py", line 71, in receive
                                                             raise ApiError(str(e), 500)
                                                         alerta.exceptions.ApiError: can only join an iterable
May 28 14:43:41 use1-alertmanager-stg-1 alertad[552191]: Fri May 28 14:43:41 2021 - SIGPIPE: writing to a closed pipe/socket/fd (probably the client disconnected) on request /api/alert (ip 10.40.144.62) !!!
May 28 14:43:41 use1-alertmanager-stg-1 alertad[552191]: Fri May 28 14:43:41 2021 - uwsgi_response_writev_headers_and_body_do(): Broken pipe [core/writer.c line 306] during POST /api/alert (10.40.144.62)
May 28 14:43:41 use1-alertmanager-stg-1 alertad[552191]: OSError: write error
May 28 14:43:41 use1-alertmanager-stg-1 alertad[552191]: [pid: 552218|app: 0|req: 1504/47917] 10.40.144.62 () {46 vars in 658 bytes} [Fri May 28 14:42:28 2021] POST /api/alert => generated 0 bytes in 73052 msecs (HTTP/1.1 500) 5 headers in 0 bytes (0 switches on core 0)
```