### PR TITLE
Added mapping from alert attributes to a specified teams channel

### DIFF
--- a/plugins/msteams/README.md
+++ b/plugins/msteams/README.md
@@ -36,6 +36,32 @@ MS_TEAMS_WEBHOOK_URL =  'https://outlook.office.com/webhook/.../IncomingWebhook/
 DASHBOARD_URL = 'http://try.alerta.io'
 ```
 
+The `MS_TEAMS_ALERT_WEBHOOK_MAPPING` configuration variable can be used to form
+a mapping based on attribute values from an alert to a specific teams webhook. 
+Also custom attributes are supported.
+For example:
+```python
+MS_TEAMS_ALERT_WEBHOOK_MAPPING = [
+    {
+        "attributes" : {
+            "event": "NodeDown",
+        },
+        "ms_teams_webhook": 'https://outlook.office.com/webhook/.../IncomingWebhook/.../...'
+    },
+        {
+        "attributes" : {
+            "custom_attribute_1": "custom_value_1",
+            "custom_attribute_2": "custom_value_2",
+            "severity": "critical",
+        },
+        "ms_teams_webhook": 'https://outlook.office.com/webhook/.../IncomingWebhook/.../...'
+    }
+]
+```
+If all attributes of an alarm are matched for multiple mappings, 
+the alarm is sent to each matching channel.
+
+
 The `MS_TEAMS_SUMMARY_FMT` configuration variable is a Jinja2 template
 string or filename to a template file and accepts any Jinja2 syntax.
 The formatter has access to two variables in the template environment,


### PR DESCRIPTION
Problem:
Currently it is not possible to send alarms to multiple channels. Also, it is not possible to filter alarms based on their attributes and assign them to a specific channel. 

Proposal for a solution:

The `MS_TEAMS_ALERT_WEBHOOK_MAPPING` configuration variable can be used to form
a mapping based on attribute values from an alert to a specific teams webhook. 
Also custom attributes are supported.
For example:
```python
MS_TEAMS_ALERT_WEBHOOK_MAPPING = [
    {
        "attributes" : {
            "event": "NodeDown",
        },
        "ms_teams_webhook": 'https://outlook.office.com/webhook/.../IncomingWebhook/.../...'
    },
        {
        "attributes" : {
            "custom_attribute_1": "custom_value_1",
            "custom_attribute_2": "custom_value_2",
            "severity": "critical",
        },
        "ms_teams_webhook": 'https://outlook.office.com/webhook/.../IncomingWebhook/.../...'
    }
]
```
If all attributes of an alarm are matched for multiple mappings, 
the alarm is sent to each matching channel.
