### PR TITLE
Add ability to get alertmanager to expire alerts

### DIFF
--- a/plugins/prometheus/README.md
+++ b/plugins/prometheus/README.md
@@ -47,6 +47,18 @@ ALERTMANAGER_API_URL = 'http://localhost:9093'
 ALERTMANAGER_SILENCE_FROM_ACK = True
 ```
 
+
+Prometheus docs specify that prometheus should send all alerts to all alertmanagers.  If you have configured your 
+ALERTMANAGER_API_URL to be a load balanced endpoint that mirrors requests to a set of alertmanagers then the following setting 
+will create/remove silences if alertmanager has set the externalUrl, the following will configure alerta to use that for silences
+ instead of the Alertmanager API URL. 
+
+Alertmanager syncs silences across all alertmanagers so only sendng it to one AM is appropriate. Using a load-balanced API that mirrors 
+requests will create one unique silenceId per alertmanager instance and sync them across all alertmanagers, which is not necessary. 
+```python
+ALERTMANAGER_USE_EXTERNALURL_FOR_SILENCES = True
+```
+
 **Robust Perception Demo Example**
 
 ```python
@@ -54,6 +66,7 @@ PLUGINS = ['reject','prometheus']
 ALERTMANAGER_API_URL = 'http://demo.robustperception.io:9093'  # default=http://localhost:9093
 ALERTMANAGER_SILENCE_DAYS = 2  # default=1
 ```
+
 
 Authentication
 --------------


### PR DESCRIPTION
When a user clicks close in Alerta the alert could remain in an open state in alertmanager, which would not send a new alert to alerta.  

This PR will take the raw_data from the original alert and add/modify the `endsAt` time to 5 minutes in the past and post it back to the Alertmanager API URL.  This will trick the Alertmanager into considering it expired and so if a new update for that alert comes in to Alertmanager it will send it along to Alerta once again which should re-open the alert.   This should help keep Alerta and Alertmanager more in sync in case an end user accidentally closes an alert that isn't actually fixed. 

Additionally, you can set a flag to tell Alert to prefer the externalUrl for an alert when setting silences.   This is handy for a situation where a user has a load balanced Alertmanager API endpoint that mirrors requests to all alertmanagers in the cluster. 
Prometheus docs specify that prometheus should send all alerts to all alertmanagers.  However, alertmanager seems to sync silences across all nodes in a cluster, so mirroring silence requests will create one silence per alertmanager and sync all of them.  Using an appropriately set externalUrl of each alertmanager will only create one and having and externalUrl set differently than the loadbalanced url is also handy for troubleshooting. 

