### PR TITLE
[Docs] Update Telegram plugin Readme

### DIFF
--- a/plugins/telegram/README.md
+++ b/plugins/telegram/README.md
@@ -31,8 +31,8 @@ server configuration file or as environment variables.
 
 ```python
 PLUGINS = ['telegram']
-TELEGRAM_TOKEN = ''  # default="not set"
-TELEGRAM_CHAT_ID = ''  # default="not set", specify multiple ID's separated by comma
+TELEGRAM_TOKEN = ''  # Required, default="not set"
+TELEGRAM_CHAT_ID = ''  # Required, default="not set", specify multiple ID's separated by comma. Get yours in https://t.me/chatid_echo_bot
 TELEGRAM_TEMPLATE = '' # default will use hardcoded one (can be a filename to template file)
 TELEGRAM_PROXY = '' # default="not set", URL must start from http://, socks5 not supported
 TELEGRAM_PROXY_USERNAME = '' # default="not set"
@@ -47,7 +47,7 @@ To `ack`, `close` or `blackout` an alert from the Telegram client set
 the webhook URL to your Alerta API Telegram endpoint (must be HTTPS):
 
 ```python
-TELEGRAM_WEBHOOK_URL = 'https://alerta.example.com/webhooks/telegram'
+TELEGRAM_WEBHOOK_URL = 'https://alerta.example.com/api/webhooks/telegram?api-key=[APIKEY_FROM_ALERTA]' # You can get one in https://alerta.example.com/keys
 BLACKOUT_DURATION = 86400   # default=3600 ie. 1 hour
 ```
 


### PR DESCRIPTION
Greetings, I've been installing this these days and found some improvements to the readme.
I've added required to the token & chat id, as well as a link to the chat id echo bot which return your chatId.

Webhook wasn't working for me until I realised id didn't have the api-key anywhere to ack/close any alert.