### PR TITLE
Add ACTION_ONLY option to Jira plugin

### DIFF
--- a/plugins/jira/README.md
+++ b/plugins/jira/README.md
@@ -28,11 +28,16 @@ server configuration file or as environment variables.
 
 ```python
 PLUGINS = ['jira']
-JIRA_PROJECT = '' #project name in jira
-JIRA_URL = ''     #url access to the jira 
-JIRA_USER = ''    #defined to the according to the jira access data
-JIRA_PASS = ''    #defined to the according to the jira access data
+JIRA_PROJECT = ''         #project name in jira
+JIRA_URL = ''             #url access to the jira 
+JIRA_ACTION_ONLY = False  #allows alerts to be sent individually
+JIRA_USER = ''            #defined according to the jira access data
+JIRA_PASS = ''            #defined according to the jira access data
 ```
+
+Action-Only Option
+------------------
+If `JIRA_ACTION_ONLY` is set to True (default is False), automatic sending of open alerts to Jira is disabled. Instead, add `jira` to the list of `ACTIONS` in alertad.conf (see [https://docs.alerta.io/configuration.html](https://docs.alerta.io/configuration.html?#web-ui-settings)). This will add an action button on each alert to manually forward it to Jira.
 
 Troubleshooting
 ---------------

--- a/plugins/jira/alerta_jira.py
+++ b/plugins/jira/alerta_jira.py
@@ -16,10 +16,13 @@ LOG = logging.getLogger('alerta.plugins.jira')
 # retrieve plugin configurations
 JIRA_URL = app.config.get('JIRA_URL') or os.environ.get('JIRA_URL')
 JIRA_PROJECT = app.config.get('JIRA_PROJECT') or os.environ.get('JIRA_PROJECT')
+JIRA_ACTION_ONLY = app.config.get('JIRA_ACTION_ONLY', False) or os.environ.get('JIRA_ACTION_ONLY', False)
 JIRA_USER = app.config.get('JIRA_USER') or os.environ.get('JIRA_USER')
 JIRA_PASS = app.config.get('JIRA_PASS') or os.environ.get('JIRA_PASS')
 
 class JiraCreate(PluginBase):
+    def __init__ (self, name=None):
+        super(JiraCreate, self).__init__(name)
 
     def _sendjira(self, host, event, value, chart, text, severity):
         LOG.info('JIRA: Create task ...')
@@ -52,43 +55,61 @@ class JiraCreate(PluginBase):
         data = res.read()            
         data = json.loads(data)
         return data["key"]
-        
+
+    def _alertjira(self, alert):
+        try:
+            LOG.info("Jira: Received an alert")
+            LOG.debug("Jira: ALERT       {}".format(alert))
+            LOG.debug("Jira: ID          {}".format(alert.id))
+            LOG.debug("Jira: RESOURCE    {}".format(alert.resource))
+            LOG.debug("Jira: EVENT       {}".format(alert.event))
+            LOG.debug("Jira: SEVERITY    {}".format(alert.severity))
+            LOG.debug("Jira: TEXT        {}".format(alert.text))
+
+            # get basic info from alert
+            host = alert.resource.split(':')[0]
+            LOG.debug("JIRA: HOST        {}".format(host))
+            chart = ".".join(alert.event.split('.')[:-1])
+            LOG.debug("JIRA: CHART       {}".format(chart))
+            event = alert.event.split('.')[-1]
+            LOG.debug("JIRA: EVENT       {}".format(event))
+
+            # call the _sendjira and modify de text (discription)
+            task = self._sendjira(host, event, alert.value, chart, alert.text, alert.severity)
+            task_url = "https://" + JIRA_URL + "/browse/" + task
+            href = '<a href="%s" target="_blank">%s</a>' %(task_url, task)
+            alert.attributes = {'Jira Task': href}
+            return alert
+
+        except Exception as e:
+            LOG.error('Jira: Failed to create task: %s', e)
+            return
+
     # reject or modify an alert before it hits the database
     def pre_receive(self, alert):
         return alert
 
     # after alert saved in database, forward alert to external systems
     def post_receive(self, alert):
-        try:
+        if not JIRA_ACTION_ONLY:
             # if the alert is critical and don't duplicate, create task in Jira
             if alert.status not in ['ack', 'closed', 'shelved'] and alert.duplicate_count == 0:
-                LOG.info("Jira: Received an alert")
-                LOG.debug("Jira: ALERT       {}".format(alert))
-                LOG.debug("Jira: ID          {}".format(alert.id))
-                LOG.debug("Jira: RESOURCE    {}".format(alert.resource))
-                LOG.debug("Jira: EVENT       {}".format(alert.event))
-                LOG.debug("Jira: SEVERITY    {}".format(alert.severity))
-                LOG.debug("Jira: TEXT        {}".format(alert.text))
-
-                # get basic info from alert
-                host = alert.resource.split(':')[0]
-                LOG.debug("JIRA: HOST        {}".format(host))
-                chart = ".".join(alert.event.split('.')[:-1])
-                LOG.debug("JIRA: CHART       {}".format(chart))
-                event = alert.event.split('.')[-1]
-                LOG.debug("JIRA: EVENT       {}".format(event))
-
-                # call the _sendjira and modify de text (discription)
-                task = self._sendjira(host, event, alert.value, chart, alert.text, alert.severity)
-                task_url = "https://" + JIRA_URL + "/browse/" + task
-                href = '<a href="%s" target="_blank">%s</a>' %(task_url, task)
-                alert.attributes = {'Jira Task': href}
+                self._alertjira(alert)
                 return alert
-
-        except Exception as e:
-            LOG.error('Jira: Failed to create task: %s', e)
+        else:
             return
 
     # triggered by external status changes, used by integrations
     def status_change(self, alert, status, text):
         return
+
+    def take_action(self, alert, action, text, **kwargs):
+        if not 'Jira Task' in alert.attributes:
+            self._alertjira(alert)
+            if 'Jira Task' in alert.attributes:
+                text = "Jira task created"
+            else:
+                text = "Jira task creation failed"
+        else:
+            text = "Jira task already exists for this alert"
+        return alert, action, text

--- a/plugins/jira/setup.py
+++ b/plugins/jira/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-version = '1.0.0'
+version = '1.1.0'
 
 setup(
     name="alerta-jira",


### PR DESCRIPTION
Allows alerts to be sent to Jira individually instead of all at once.