### PR TITLE
Add IP2Location.io plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Plugins
   * [Forward](plugins/forward)
   * [GeoIP](plugins/geoip)
   * [InfluxDB](plugins/influxdb)
+  * [Ip2Location.io](plugins/ip2locationio)
   * [Logstash](plugins/logstash)
   * [Matrix](plugins/matrix)
   * [Mattermost](plugins/mattermost)

--- a/plugins/ip2locationio/README.md
+++ b/plugins/ip2locationio/README.md
@@ -1,0 +1,65 @@
+IP2Locationio Plugin
+====================
+
+Query geolocation information for the origin IP address from IP2Location.io API.
+
+For help, join [![Slack chat](https://img.shields.io/badge/chat-on%20slack-blue?logo=slack)](https://slack.alerta.dev)
+
+Prerequisite
+------------
+This plugin requires an API key to function. You may sign up for a free API key at https://www.ip2location.io/pricing.
+
+Installation
+------------
+
+Clone the GitHub repo and run:
+
+    $ python setup.py install
+
+Or, to install remotely from GitHub run:
+
+    $ pip install git+https://github.com/alerta/alerta-contrib.git#subdirectory=plugins/ip2locationio
+
+Note: If Alerta is installed in a python virtual environment then plugins
+need to be installed into the same environment for Alerta to dynamically
+discover them.
+
+Configuration
+-------------
+
+Add `ip2locationio` to the list of enabled `PLUGINS` in `alertad.conf` server
+configuration file and set plugin-specific variables either in the
+server configuration file or as environment variables. For example:
+
+```python
+PLUGINS = ['reject', 'remote_ip', 'geoip']
+IP2LOCATIONIO_ACCESS_KEY = 'YOUR_IP2LOCATIONIO_API_KEY'
+```
+
+**Sample output**
+
+
+
+```json
+{
+    "alert": {
+        "attributes": {
+            "as":"Google LLC"
+            "asn":"15169",
+            "city": "Mountain View",
+            "country": "US",
+            "ip": "8.8.8.8",
+            "latitude":37.38605,
+            "longitude":-122.08385,
+            "state": "California",
+            "time_zone":"-08:00",
+            "zip_code":"94035"
+        },
+        ...
+      }
+    }
+```
+License
+-------
+
+Copyright (c) 2024 IP2Location.io. Available under the MIT License.

--- a/plugins/ip2locationio/README.md
+++ b/plugins/ip2locationio/README.md
@@ -14,7 +14,7 @@ Installation
 
 Clone the GitHub repo and run:
 
-    $ python setup.py install
+    $ python3 setup.py install
 
 Or, to install remotely from GitHub run:
 
@@ -44,7 +44,7 @@ IP2LOCATIONIO_ACCESS_KEY = 'YOUR_IP2LOCATIONIO_API_KEY'
 {
     "alert": {
         "attributes": {
-            "as":"Google LLC"
+            "as":"Google LLC",
             "asn":"15169",
             "city": "Mountain View",
             "country": "US",

--- a/plugins/ip2locationio/alerta_ip2locationio.py
+++ b/plugins/ip2locationio/alerta_ip2locationio.py
@@ -35,17 +35,10 @@ class IP2Locationio(PluginBase):
         LOG.debug('Result: %s', r.text)
         try:
             ip2locationio_result = r.json()
+            if 'country' in ip2locationio_result and 'language' in ip2locationio_result['country']:
+                ip2locationio_result['country']['official_language'] = ip2locationio_result['country'].pop('language')
             alert.attributes = {
-                'ip': ip2locationio_result['ip'],
-                'country': ip2locationio_result['country_code'],
-                'country': ip2locationio_result['country_code'],
-                'state': ip2locationio_result['region_name'],
-                'city': ip2locationio_result['city_name'],
-                'latitude': ip2locationio_result['latitude'],
-                'longitude': ip2locationio_result['longitude'],
-                'time_zone': ip2locationio_result['time_zone'],
-                'asn': ip2locationio_result['asn'],
-                'as': ip2locationio_result['as']
+                'ip2locationio_result': ip2locationio_result
             }
         except Exception as e:
             LOG.error('IP2Location.io lookup failed: %s' % str(e))

--- a/plugins/ip2locationio/alerta_ip2locationio.py
+++ b/plugins/ip2locationio/alerta_ip2locationio.py
@@ -9,7 +9,7 @@ try:
 except ImportError:
     from alerta.app import app  # alerta < 5.0
 
-LOG = logging.getLogger('alerta.plugins.ip2locationpy')
+LOG = logging.getLogger('alerta.plugins.ip2locationio')
 
 IP2LOCATIONIO_URL = 'https://api.ip2location.io'
 IP2LOCATIONIO_ACCESS_KEY = os.environ.get(
@@ -27,19 +27,17 @@ class IP2Locationio(PluginBase):
                                                ip_addr)
         else:
             LOG.warning('IP address must be included as an alert attribute.')
-            raise RuntimeWarning(
-                'IP address must be included as an alert attribute.')
+            return alert
 
         r = requests.get(
             url, headers={'Content-type': 'application/json'}, timeout=2)
         LOG.debug('Result: %s', r.text)
         try:
+            r.raise_for_status()
             ip2locationio_result = r.json()
             if 'country' in ip2locationio_result and 'language' in ip2locationio_result['country']:
                 ip2locationio_result['country']['official_language'] = ip2locationio_result['country'].pop('language')
-            alert.attributes = {
-                'ip2locationio_result': ip2locationio_result
-            }
+            alert.attributes.update(ip2locationio_result=ip2locationio_result)
         except Exception as e:
             LOG.error('IP2Location.io lookup failed: %s' % str(e))
             raise RuntimeError('IP2Location.io lookup failed: %s' % str(e))

--- a/plugins/ip2locationio/ip2locationio.py
+++ b/plugins/ip2locationio/ip2locationio.py
@@ -1,0 +1,60 @@
+import logging
+import os
+
+import requests
+from alerta.plugins import PluginBase
+
+try:
+    from alerta.plugins import app  # alerta >= 5.0
+except ImportError:
+    from alerta.app import app  # alerta < 5.0
+
+LOG = logging.getLogger('alerta.plugins.ip2locationpy')
+
+IP2LOCATIONIO_URL = 'https://api.ip2location.io'
+IP2LOCATIONIO_ACCESS_KEY = os.environ.get(
+    'IP2LOCATIONIO_ACCESS_KEY') or app.config.get('IP2LOCATIONIO_ACCESS_KEY', None)
+
+
+class IP2Locationio(PluginBase):
+
+    def pre_receive(self, alert):
+
+        if 'ip' in alert.attributes:
+            ip_addr = alert.attributes['ip'].split(', ')[0]
+            LOG.debug('IP2Location.io lookup for IP: %s', ip_addr)
+            url = '{}/?key={}&ip={}'.format(IP2LOCATIONIO_URL, IP2LOCATIONIO_ACCESS_KEY,
+                                               ip_addr)
+        else:
+            LOG.warning('IP address must be included as an alert attribute.')
+            raise RuntimeWarning(
+                'IP address must be included as an alert attribute.')
+
+        r = requests.get(
+            url, headers={'Content-type': 'application/json'}, timeout=2)
+        LOG.debug('Result: %s', r.text)
+        try:
+            ip2locationio_result = r.json()
+            alert.attributes = {
+                'ip': ip2locationio_result['ip'],
+                'country': ip2locationio_result['country_code'],
+                'country': ip2locationio_result['country_code'],
+                'state': ip2locationio_result['region_name'],
+                'city': ip2locationio_result['city_name'],
+                'latitude': ip2locationio_result['latitude'],
+                'longitude': ip2locationio_result['longitude'],
+                'time_zone': ip2locationio_result['time_zone'],
+                'asn': ip2locationio_result['asn'],
+                'as': ip2locationio_result['as']
+            }
+        except Exception as e:
+            LOG.error('IP2Location.io lookup failed: %s' % str(e))
+            raise RuntimeError('IP2Location.io lookup failed: %s' % str(e))
+
+        return alert
+
+    def post_receive(self, alert):
+        return
+
+    def status_change(self, alert, status, text):
+        return

--- a/plugins/ip2locationio/setup.py
+++ b/plugins/ip2locationio/setup.py
@@ -10,9 +10,11 @@ setup(
     license='MIT',
     author='IP2Location',
     author_email='support@ip2location.com',
-    py_modules=['ip2locationio'],
+    py_modules=['alerta_ip2locationio'],
     packages=find_packages(),
-    install_requires=[],
+    install_requires=[
+        'requests'
+    ],
     include_package_data=True,
     zip_safe=True,
     entry_points={

--- a/plugins/ip2locationio/setup.py
+++ b/plugins/ip2locationio/setup.py
@@ -1,0 +1,23 @@
+from setuptools import setup, find_packages
+
+version = '1.0.0'
+
+setup(
+    name="alerta-ip2locationio",
+    version=version,
+    description='Alerta plugin to query geolocation information from IP2Location.io API.',
+    url='https://github.com/alerta/alerta-contrib',
+    license='MIT',
+    author='IP2Location',
+    author_email='support@ip2location.com',
+    py_modules=['ip2locationio'],
+    packages=find_packages(),
+    install_requires=[],
+    include_package_data=True,
+    zip_safe=True,
+    entry_points={
+        'alerta.plugins': [
+            'ip2locationio = alerta_ip2locationio:IP2Locationio'
+        ]
+    }
+)


### PR DESCRIPTION
**Description**
Add IP2Location.io plugin as an option to lookup for geolocation information for the origin IP address.

**Changes**
Include a brief summary of changes...
- Add IP2Location.io plugin.

**Checklist**
- [x] Pull request is limited to a single purpose
- [x] Code style/formatting is consistent
- [x] All existing tests are passing
- [x] Added new tests related to change
- [x] No unnecessary whitespace changes

**Collaboration**
When a user creates a pull request from a fork that they own, the user
generally has the authority to decide if other users can commit to the
pull request's compare branch. If the pull request author wants greater
collaboration, they can grant maintainers of the upstream repository
(that is, anyone with push access to the upstream repository) permission
to commit to the pull request's compare branch

See https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork

