### PR TITLE
[Issue-Fix] jinja2.ext.autoescape extension

### DIFF
--- a/integrations/mailer/mailer.py
+++ b/integrations/mailer/mailer.py
@@ -170,7 +170,6 @@ class MailSender(threading.Thread):
         self._subject_template = jinja2.Template(OPTIONS['mail_subject'])
         self._template_env = jinja2.Environment(
             loader=jinja2.FileSystemLoader(self._template_dir),
-            extensions=['jinja2.ext.autoescape'],
             autoescape=True
         )
         if OPTIONS['mail_template_html']:


### PR DESCRIPTION
**Description**
The pull request resolves a bug in alerta-mailer, where the code uses a deprecated Jinja2 feature. Specifically, the jinja2.ext.autoescape extension has been removed in newer versions of Jinja2.

Fixes # (issue)

**Changes**
- Removed the deprecated extension from jinja2 initialization

**Screenshots**
If it's a UI change add screenshots to demonstrate changes.

**Checklist**
- [ ] Pull request is limited to a single purpose
- [ ] Code style/formatting is consistent
- [ ] All existing tests are passing
- [ ] Added new tests related to change
- [ ] No unnecessary whitespace changes

**Collaboration**
When a user creates a pull request from a fork that they own, the user
generally has the authority to decide if other users can commit to the
pull request's compare branch. If the pull request author wants greater
collaboration, they can grant maintainers of the upstream repository
(that is, anyone with push access to the upstream repository) permission
to commit to the pull request's compare branch

See https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork

