### PR TITLE
feat: support Alertmanager version > 0.27.0

### DIFF
--- a/plugins/prometheus/alerta_prometheus.py
+++ b/plugins/prometheus/alerta_prometheus.py
@@ -59,7 +59,7 @@ class AlertmanagerSilence(PluginBase):
                           alert.event, alert.resource)
                 base_url = ALERTMANAGER_API_URL or alert.attributes.get(
                     'externalUrl', DEFAULT_ALERTMANAGER_API_URL)
-                url = base_url + '/api/v1/silence/%s' % silenceId
+                url = base_url + '/api/v2/silence/%s' % silenceId
                 try:
                     r = requests.delete(url, auth=self.auth, timeout=2)
                 except Exception as e:
@@ -90,7 +90,7 @@ class AlertmanagerSilence(PluginBase):
         if action == 'close':
             LOG.warning(
                 'Got a close action so trying to close this in alertmanager too')
-            url = base_url + '/api/v1/alerts'
+            url = base_url + '/api/v2/alerts'
             raw_data_string = alert.raw_data
             raw_data = json.loads(raw_data_string)
             # set the endsAt to now so alertmanager will consider it expired or whatever
@@ -126,11 +126,13 @@ class AlertmanagerSilence(PluginBase):
                 'matchers': [
                     {
                         'name': 'alertname',
-                        'value': alert.event
+                        'value': alert.event,
+                        "isRegex": False
                     },
                     {
                         'name': 'instance',
-                        'value': alert.resource
+                        'value': alert.resource,
+                        "isRegex": False
                     }
                 ],
                 'startsAt': datetime.datetime.utcnow().replace(microsecond=0).isoformat() + '.000Z',
@@ -149,7 +151,7 @@ class AlertmanagerSilence(PluginBase):
                 base_url = ALERTMANAGER_API_URL or alert.attributes.get(
                     'externalUrl', DEFAULT_ALERTMANAGER_API_URL)
 
-            url = base_url + '/api/v1/silences'
+            url = base_url + '/api/v2/silences'
 
             try:
                 r = requests.post(url, json=data, auth=self.auth, timeout=2)
@@ -178,7 +180,7 @@ class AlertmanagerSilence(PluginBase):
             if silenceId:
                 base_url = ALERTMANAGER_API_URL or alert.attributes.get(
                     'externalUrl', DEFAULT_ALERTMANAGER_API_URL)
-                url = base_url + '/api/v1/silence/%s' % silenceId
+                url = base_url + '/api/v2/silence/%s' % silenceId
                 try:
                     r = requests.delete(url, auth=self.auth, timeout=2)
                 except Exception as e:


### PR DESCRIPTION
**Description**
Alertmanager API v1 has been remove since version 0.27.0.

Fixes #407

**Changes**

- Use v2 API path. 
- Add v2 requeried params for silences.

**Checklist**
- [X] Pull request is limited to a single purpose
- [X] Code style/formatting is consistent
- [X] All existing tests are passing
- [ ] Added new tests related to change
- [ ] No unnecessary whitespace changes