### PR TITLE
feat: migrate Prometheus plugin from Alertmanager API v1 to v2

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,2 +1,2 @@
 [settings]
-known_third_party = Queue,alerta,alerta_azuremonitor,alerta_msteamswebhook,alerta_sentry,alerta_slack,alertaclient,boto,cachetclient,consul,dateutil,dingtalkchatbot,flask,google,influxdb,jinja2,kombu,mailer,matterhook,mock,op5,pymsteams,pytest,pyzabbix,requests,settings,setuptools,telepot,twilio,yaml
+known_third_party = Queue,alerta,alerta_azuremonitor,alerta_msteamswebhook,alerta_prometheus,alerta_sentry,alerta_slack,alertaclient,boto,cachetclient,consul,dateutil,dingtalkchatbot,flask,google,influxdb,jinja2,kombu,mailer,matterhook,mock,op5,pymsteams,pytest,pyzabbix,requests,settings,setuptools,telepot,twilio,yaml

--- a/plugins/prometheus/README.md
+++ b/plugins/prometheus/README.md
@@ -5,6 +5,10 @@ Two-way integration with Prometheus which will silence alerts in
 Alertmanager when alerts are ack'ed in the Alerta console and delete
 silences if those alerts are manually re-opened.
 
+Uses the [Alertmanager API v2](https://github.com/prometheus/alertmanager/blob/main/api/v2/openapi.yaml).
+Requires Alertmanager >= 0.16.0 (v2 API). Alertmanager removed the
+v1 API entirely in version 0.28.0.
+
 For help, join [![Slack chat](https://img.shields.io/badge/chat-on%20slack-blue?logo=slack)](https://slack.alerta.dev)
 
 Installation
@@ -33,30 +37,27 @@ the server configuration file or as environment variables.
 PLUGINS = ['prometheus']
 ```
 
-The below settings are configured with reasonable defaults:
+**Settings**
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `ALERTMANAGER_API_URL` | `http://localhost:9093` | Alertmanager base URL |
+| `ALERTMANAGER_SILENCE_DAYS` | `1` | Silence duration in days |
+| `ALERTMANAGER_SILENCE_DURATION` | *none* | Silence duration with units (see below). Takes precedence over `ALERTMANAGER_SILENCE_DAYS`. |
+| `ALERTMANAGER_SILENCE_FROM_ACK` | `False` | Create silences when alerts are ack'ed |
+| `ALERTMANAGER_USE_EXTERNALURL_FOR_SILENCES` | `False` | Use Alertmanager's `externalUrl` for silence API calls |
+| `ALERTMANAGER_SSL_VERIFY` | `True` | SSL verification. Set to `False` to disable, or a file path for a custom CA bundle. |
+| `ALERTMANAGER_USERNAME` | *none* | Basic auth username |
+| `ALERTMANAGER_PASSWORD` | *none* | Basic auth password |
+
+All settings can be set as environment variables or in `alertad.conf`.
+
+**Basic Example**
 
 ```python
-ALERTMANAGER_API_URL = 'http://localhost:9093'
-ALERTMANAGER_SILENCE_DAYS = 1
-```
-
-Or, if you want to inherit silence timeout from ack timeout:
-
-```python
+PLUGINS = ['reject', 'prometheus']
 ALERTMANAGER_API_URL = 'http://localhost:9093'
 ALERTMANAGER_SILENCE_FROM_ACK = True
-```
-
-
-Prometheus docs specify that prometheus should send all alerts to all alertmanagers.  If you have configured your
-ALERTMANAGER_API_URL to be a load balanced endpoint that mirrors requests to a set of alertmanagers then the following setting
-will create/remove silences if alertmanager has set the externalUrl, the following will configure alerta to use that for silences
- instead of the Alertmanager API URL.
-
-Alertmanager syncs silences across all alertmanagers so only sendng it to one AM is appropriate. Using a load-balanced API that mirrors
-requests will create one unique silenceId per alertmanager instance and sync them across all alertmanagers, which is not necessary.
-```python
-ALERTMANAGER_USE_EXTERNALURL_FOR_SILENCES = True
 ```
 
 **Silence Duration**
@@ -73,17 +74,22 @@ ALERTMANAGER_SILENCE_DURATION = '90s'  # 90 seconds
 
 Supported units: `s` (seconds), `m` (minutes), `h` (hours), `d` (days), `w` (weeks).
 Plain integers without a unit are treated as days for backward compatibility
-with `ALERTMANAGER_SILENCE_DAYS`. If both are set, `ALERTMANAGER_SILENCE_DURATION`
-takes precedence.
+with `ALERTMANAGER_SILENCE_DAYS`.
 
-**Robust Perception Demo Example**
+**Clustered Alertmanagers**
+
+Prometheus docs specify that Prometheus should send all alerts to all
+Alertmanagers. If you have configured `ALERTMANAGER_API_URL` to be a
+load-balanced endpoint that mirrors requests, the following setting will
+use Alertmanager's `externalUrl` for silence API calls instead:
 
 ```python
-PLUGINS = ['reject','prometheus']
-ALERTMANAGER_API_URL = 'http://demo.robustperception.io:9093'  # default=http://localhost:9093
-ALERTMANAGER_SILENCE_DAYS = 2  # default=1
+ALERTMANAGER_USE_EXTERNALURL_FOR_SILENCES = True
 ```
 
+Alertmanager syncs silences across instances, so sending to a single
+instance is sufficient. A load-balanced API that mirrors requests would
+create duplicate silences.
 
 SSL Verification
 ----------------
@@ -105,10 +111,7 @@ by default. For convenience, this plugin will support Basic Auth if it has
 been configured (using a reverse proxy or otherwise). Any other form of
 authentication will require development work by the user.
 
-**Example of BasicAuth configuration**
-
 ```python
-ALERTMANAGER_API_URL = 'http://localhost:9093'
 ALERTMANAGER_USERNAME = 'promuser'
 ALERTMANAGER_PASSWORD = 'prompass'
 ```
@@ -122,22 +125,16 @@ Set `DEBUG=True` in the `alertad.conf` configuration file and look for log
 entries similar to below:
 
 ```
-2016-11-20 23:02:40,623 - alerta.plugins[7394]: DEBUG - Server plug-in 'prometheus' found. [in /var/lib/.virtualenvs/alerta/lib/python2.7/site-packages/alerta_server-4.8.11-py2.7.egg/alerta/plugins/__init__.py:50]
-2016-11-20 23:02:40,623 - alerta.plugins[7394]: DEBUG - Server plug-in 'prometheus' not enabled in 'PLUGINS'. [in /var/lib/.virtualenvs/alerta/lib/python2.7/site-packages/alerta_server-4.8.11-py2.7.egg/alerta/plugins/__init__.py:59]
-```
-```
-2016-11-21 10:42:55,572 - alerta.plugins.prometheus[8268]: DEBUG - Alertmanager: Add silence for alertname=DiskFull instance=web01 [in build/bdist.macosx-10.12-x86_64/egg/alerta_prometheus.py:35]
-2016-11-21 10:42:55,582 - requests.packages.urllib3.connectionpool[8268]: INFO - Starting new HTTP connection (1): demo.robustperception.io [in /var/lib/.virtualenvs/alerta/lib/python2.7/site-packages/requests-2.11.1-py2.7.egg/requests/packages/urllib3/connectionpool.py:214]
-2016-11-21 10:42:55,677 - requests.packages.urllib3.connectionpool[8268]: DEBUG - "POST /api/v1/silences HTTP/1.1" 200 44 [in /var/lib/.virtualenvs/alerta/lib/python2.7/site-packages/requests-2.11.1-py2.7.egg/requests/packages/urllib3/connectionpool.py:401]
-2016-11-21 10:42:55,711 - alerta.plugins.prometheus[8268]: DEBUG - Alertmanager: 200 - {"status":"success","data":{"silenceId":29}} [in build/bdist.macosx-10.12-x86_64/egg/alerta_prometheus.py:59]
-2016-11-21 10:42:55,715 - alerta.plugins.prometheus[8268]: DEBUG - Alertmanager: Added silenceId 29 to attributes [in build/bdist.macosx-10.12-x86_64/egg/alerta_prometheus.py:67]
+alerta.plugins.prometheus: DEBUG - Alertmanager: Add silence for alertname=DiskFull instance=web01 timeout=86400
+alerta.plugins.prometheus: DEBUG - Alertmanager: 200 - {"silenceID":"73373e3f-a928-450a-ba75-e9254297b483"}
+alerta.plugins.prometheus: DEBUG - Alertmanager: Added silenceId 73373e3f-a928-450a-ba75-e9254297b483 to attributes
 ```
 
 References
 ----------
 
+  * Alertmanager API v2 OpenAPI Spec: https://github.com/prometheus/alertmanager/blob/main/api/v2/openapi.yaml
   * Alertmanager Silences: https://prometheus.io/docs/alerting/alertmanager/#silences
-  * Robust Perception On-line Demo: http://demo.robustperception.io:9090/consoles/index.html
 
 License
 -------

--- a/plugins/prometheus/alerta_prometheus.py
+++ b/plugins/prometheus/alerta_prometheus.py
@@ -89,7 +89,7 @@ class AlertmanagerSilence(PluginBase):
                           alert.event, alert.resource)
                 base_url = ALERTMANAGER_API_URL or alert.attributes.get(
                     'externalUrl', DEFAULT_ALERTMANAGER_API_URL)
-                url = base_url + '/api/v1/silence/%s' % silenceId
+                url = base_url + '/api/v2/silence/%s' % silenceId
                 try:
                     r = requests.delete(
                         url, auth=self.auth, timeout=2, verify=ALERTMANAGER_SSL_VERIFY)
@@ -121,7 +121,7 @@ class AlertmanagerSilence(PluginBase):
         if action == 'close':
             LOG.warning(
                 'Got a close action so trying to close this in alertmanager too')
-            url = base_url + '/api/v1/alerts'
+            url = base_url + '/api/v2/alerts'
             raw_data_string = alert.raw_data
             raw_data = json.loads(raw_data_string)
             # set the endsAt to now so alertmanager will consider it expired or whatever
@@ -166,11 +166,13 @@ class AlertmanagerSilence(PluginBase):
                 'matchers': [
                     {
                         'name': 'alertname',
-                        'value': alert.event
+                        'value': alert.event,
+                        'isRegex': False
                     },
                     {
                         'name': 'instance',
-                        'value': alert.resource
+                        'value': alert.resource,
+                        'isRegex': False
                     }
                 ],
                 'startsAt': datetime.datetime.utcnow().replace(microsecond=0).isoformat() + '.000Z',
@@ -189,7 +191,7 @@ class AlertmanagerSilence(PluginBase):
                 base_url = ALERTMANAGER_API_URL or alert.attributes.get(
                     'externalUrl', DEFAULT_ALERTMANAGER_API_URL)
 
-            url = base_url + '/api/v1/silences'
+            url = base_url + '/api/v2/silences'
 
             try:
                 r = requests.post(url, json=data, auth=self.auth,
@@ -198,11 +200,11 @@ class AlertmanagerSilence(PluginBase):
                 raise RuntimeError('Alertmanager: ERROR - %s' % e)
             LOG.debug('Alertmanager: %s - %s', r.status_code, r.text)
 
-            # example r={"status":"success","data":{"silenceId":8}}
+            # v2 API returns {"silenceID": "..."} directly
             try:
-                data = r.json().get('data', [])
-                if data:
-                    silenceId = data['silenceId']
+                response_data = r.json()
+                silenceId = response_data.get('silenceID')
+                if silenceId:
                     alert.attributes['silenceId'] = silenceId
                 else:
                     silenceId = alert.attributes.get('silenceId', 'unknown')
@@ -219,7 +221,7 @@ class AlertmanagerSilence(PluginBase):
             if silenceId:
                 base_url = ALERTMANAGER_API_URL or alert.attributes.get(
                     'externalUrl', DEFAULT_ALERTMANAGER_API_URL)
-                url = base_url + '/api/v1/silence/%s' % silenceId
+                url = base_url + '/api/v2/silence/%s' % silenceId
                 try:
                     r = requests.delete(
                         url, auth=self.auth, timeout=2, verify=ALERTMANAGER_SSL_VERIFY)

--- a/plugins/prometheus/setup.py
+++ b/plugins/prometheus/setup.py
@@ -1,6 +1,6 @@
 from setuptools import find_packages, setup
 
-version = '5.4.0'
+version = '6.0.0'
 
 setup(
     name='alerta-prometheus',

--- a/plugins/prometheus/test_prometheus.py
+++ b/plugins/prometheus/test_prometheus.py
@@ -6,7 +6,6 @@ https://github.com/prometheus/alertmanager/blob/main/api/v2/openapi.yaml
 """
 
 import json
-import os
 import unittest
 from unittest.mock import MagicMock, patch
 

--- a/plugins/prometheus/test_prometheus.py
+++ b/plugins/prometheus/test_prometheus.py
@@ -10,11 +10,8 @@ import os
 import unittest
 from unittest.mock import MagicMock, patch
 
-os.environ['ALERTMANAGER_API_URL'] = 'http://alertmanager:9093'
-os.environ['ALERTMANAGER_SILENCE_FROM_ACK'] = 'true'
-
-from alerta.app import create_app  # noqa: E402
-from alerta_prometheus import AlertmanagerSilence, parse_duration  # noqa: E402
+from alerta.app import create_app
+from alerta_prometheus import AlertmanagerSilence, parse_duration
 
 
 class ParseDurationTestCase(unittest.TestCase):
@@ -102,6 +99,7 @@ class AlertmanagerSilenceTestCase(unittest.TestCase):
         data = json.loads(response.data.decode('utf-8'))
         return data['alert']
 
+    @patch('alerta_prometheus.ALERTMANAGER_SILENCE_FROM_ACK', True)
     @patch('alerta_prometheus.requests.post')
     def test_ack_creates_silence_via_v2_api(self, mock_post):
         """POST /api/v2/silences should be called on ack.

--- a/plugins/prometheus/test_prometheus.py
+++ b/plugins/prometheus/test_prometheus.py
@@ -14,10 +14,7 @@ os.environ['ALERTMANAGER_API_URL'] = 'http://alertmanager:9093'
 os.environ['ALERTMANAGER_SILENCE_FROM_ACK'] = 'true'
 
 from alerta.app import create_app  # noqa: E402
-from alerta_prometheus import (  # noqa: E402
-    AlertmanagerSilence,
-    parse_duration,
-)
+from alerta_prometheus import AlertmanagerSilence, parse_duration  # noqa: E402
 
 
 class ParseDurationTestCase(unittest.TestCase):

--- a/plugins/prometheus/test_prometheus.py
+++ b/plugins/prometheus/test_prometheus.py
@@ -1,0 +1,244 @@
+"""
+Unit tests for the Prometheus Alertmanager plugin.
+
+API v2 request/response formats are based on the Alertmanager OpenAPI spec:
+https://github.com/prometheus/alertmanager/blob/main/api/v2/openapi.yaml
+"""
+
+import json
+import os
+import unittest
+from unittest.mock import MagicMock, patch
+
+os.environ['ALERTMANAGER_API_URL'] = 'http://alertmanager:9093'
+os.environ['ALERTMANAGER_SILENCE_FROM_ACK'] = 'true'
+
+from alerta.app import create_app  # noqa: E402
+from alerta_prometheus import (  # noqa: E402
+    AlertmanagerSilence,
+    parse_duration,
+)
+
+
+class ParseDurationTestCase(unittest.TestCase):
+
+    def test_integer_treated_as_days(self):
+        assert parse_duration(1) == 86400
+        assert parse_duration(7) == 604800
+
+    def test_seconds(self):
+        assert parse_duration('90s') == 90
+        assert parse_duration('0s') == 0
+
+    def test_minutes(self):
+        assert parse_duration('30m') == 1800
+
+    def test_hours(self):
+        assert parse_duration('2h') == 7200
+
+    def test_days(self):
+        assert parse_duration('1d') == 86400
+
+    def test_weeks(self):
+        assert parse_duration('1w') == 604800
+
+    def test_plain_integer_string_treated_as_days(self):
+        assert parse_duration('3') == 259200
+
+    def test_case_insensitive(self):
+        assert parse_duration('2H') == 7200
+        assert parse_duration('1D') == 86400
+
+    def test_invalid_raises(self):
+        with self.assertRaises(ValueError):
+            parse_duration('abc')
+        with self.assertRaises(ValueError):
+            parse_duration('10x')
+        with self.assertRaises(ValueError):
+            parse_duration('')
+
+
+class AlertmanagerSilenceTestCase(unittest.TestCase):
+    """
+    Tests verify that the plugin uses Alertmanager API v2 endpoints and
+    correctly handles v2 response formats per the OpenAPI spec:
+    https://github.com/prometheus/alertmanager/blob/main/api/v2/openapi.yaml
+    """
+
+    def setUp(self):
+        config = {
+            'TESTING': True,
+            'AUTH_REQUIRED': False,
+        }
+        self.app = create_app(config)
+        self.client = self.app.test_client()
+        self.plugin = AlertmanagerSilence()
+
+        # Create a prometheus alert
+        self.prom_alert = {
+            'event': 'DiskFull',
+            'resource': 'web01',
+            'environment': 'Production',
+            'service': ['Web'],
+            'severity': 'critical',
+            'correlate': ['DiskFull', 'DiskOk'],
+            'tags': [],
+            'attributes': {},
+            'raw_data': json.dumps({
+                'labels': {'alertname': 'DiskFull', 'instance': 'web01'},
+                'startsAt': '2024-01-01T00:00:00.000Z',
+                'endsAt': '0001-01-01T00:00:00Z',
+                'generatorURL': 'http://prometheus:9090/graph',
+            }),
+        }
+
+    def _create_alert(self):
+        """Create an alert via the API and return it."""
+        response = self.client.post(
+            '/alert', data=json.dumps(self.prom_alert),
+            headers={'Content-type': 'application/json'})
+        self.assertEqual(response.status_code, 201)
+        data = json.loads(response.data.decode('utf-8'))
+        alert_id = data['id']
+        # Fetch the full alert object
+        response = self.client.get('/alert/%s' % alert_id)
+        data = json.loads(response.data.decode('utf-8'))
+        return data['alert']
+
+    @patch('alerta_prometheus.requests.post')
+    def test_ack_creates_silence_via_v2_api(self, mock_post):
+        """POST /api/v2/silences should be called on ack.
+
+        Per the OpenAPI spec, the response is: {"silenceID": "<uuid>"}
+        """
+        # Mock the v2 silence creation response
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.text = '{"silenceID":"73373e3f-a928-450a-ba75-e9254297b483"}'
+        mock_response.json.return_value = {
+            'silenceID': '73373e3f-a928-450a-ba75-e9254297b483'
+        }
+        mock_post.return_value = mock_response
+
+        alert_data = self._create_alert()
+
+        from alerta.models.alert import Alert
+        alert = Alert.parse(alert_data)
+        alert.event_type = 'prometheusAlert'
+
+        result = self.plugin.take_action(alert, 'ack', 'acked by user')
+
+        # Verify v2 endpoint was called
+        call_args = mock_post.call_args
+        url = call_args[0][0]
+        self.assertIn('/api/v2/silences', url)
+        self.assertNotIn('/api/v1/', url)
+
+        # Verify request body contains isRegex per v2 spec
+        request_body = call_args[1]['json']
+        for matcher in request_body['matchers']:
+            self.assertIn('isRegex', matcher)
+            self.assertFalse(matcher['isRegex'])
+
+        # Verify required fields per v2 postableSilence schema
+        self.assertIn('startsAt', request_body)
+        self.assertIn('endsAt', request_body)
+        self.assertIn('createdBy', request_body)
+        self.assertIn('comment', request_body)
+
+        # Verify silenceID was extracted from v2 response
+        self.assertEqual(
+            result.attributes['silenceId'],
+            '73373e3f-a928-450a-ba75-e9254297b483')
+
+    @patch('alerta_prometheus.requests.post')
+    def test_close_expires_alert_via_v2_api(self, mock_post):
+        """POST /api/v2/alerts should be called on close."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.text = ''
+        mock_post.return_value = mock_response
+
+        alert_data = self._create_alert()
+
+        from alerta.models.alert import Alert
+        alert = Alert.parse(alert_data)
+        alert.event_type = 'prometheusAlert'
+        alert.raw_data = self.prom_alert['raw_data']
+
+        self.plugin.take_action(alert, 'close', 'closing alert')
+
+        call_args = mock_post.call_args
+        url = call_args[0][0]
+        self.assertIn('/api/v2/alerts', url)
+        self.assertNotIn('/api/v1/', url)
+
+    @patch('alerta_prometheus.requests.delete')
+    def test_unack_deletes_silence_via_v2_api(self, mock_delete):
+        """DELETE /api/v2/silence/{silenceID} should be called on unack."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.text = ''
+        mock_delete.return_value = mock_response
+
+        alert_data = self._create_alert()
+
+        from alerta.models.alert import Alert
+        alert = Alert.parse(alert_data)
+        alert.event_type = 'prometheusAlert'
+        alert.attributes['silenceId'] = '73373e3f-a928-450a-ba75-e9254297b483'
+
+        result = self.plugin.take_action(alert, 'unack', 'unacked')
+
+        call_args = mock_delete.call_args
+        url = call_args[0][0]
+        self.assertIn('/api/v2/silence/73373e3f-a928-450a-ba75-e9254297b483',
+                      url)
+        self.assertNotIn('/api/v1/', url)
+
+        # silenceId should be cleared
+        self.assertIsNone(result.attributes['silenceId'])
+
+    @patch('alerta_prometheus.requests.delete')
+    def test_status_change_deletes_silence_via_v2_api(self, mock_delete):
+        """DELETE /api/v2/silence/{silenceID} should be called on open/closed status."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.text = ''
+        mock_delete.return_value = mock_response
+
+        alert_data = self._create_alert()
+
+        from alerta.models.alert import Alert
+        alert = Alert.parse(alert_data)
+        alert.attributes['silenceId'] = 'abc-123'
+
+        result = self.plugin.status_change(alert, 'open', '')
+
+        call_args = mock_delete.call_args
+        url = call_args[0][0]
+        self.assertIn('/api/v2/silence/abc-123', url)
+        self.assertNotIn('/api/v1/', url)
+        self.assertIsNone(result.attributes['silenceId'])
+
+    def test_non_prometheus_alert_ignored(self):
+        """Non-prometheusAlert events should be returned unchanged."""
+        alert_data = self._create_alert()
+
+        from alerta.models.alert import Alert
+        alert = Alert.parse(alert_data)
+        alert.event_type = 'otherType'
+
+        result = self.plugin.take_action(alert, 'ack', 'test')
+        self.assertEqual(result, alert)
+
+    def test_status_change_without_silence_is_noop(self):
+        """Status change with no silenceId should not make any HTTP calls."""
+        alert_data = self._create_alert()
+
+        from alerta.models.alert import Alert
+        alert = Alert.parse(alert_data)
+
+        with patch('alerta_prometheus.requests.delete') as mock_delete:
+            self.plugin.status_change(alert, 'open', '')
+            mock_delete.assert_not_called()


### PR DESCRIPTION
## Summary
- Replace all `/api/v1/` endpoints with `/api/v2/` (silences, alerts, silence delete)
- Add required `isRegex` field to silence matchers (v2 API requires this)
- Fix silence response parsing for v2 format (`{"silenceID": "..."}` at top level instead of `{"status":"success","data":{"silenceId":...}}`)

Alertmanager deprecated API v1 in 0.16.0 and removed it entirely in 0.28.0, returning HTTP 410 for all v1 requests.

Fixes #407
Supersedes #410

## Test plan
- [ ] Verify ack creates a silence via `/api/v2/silences`
- [ ] Verify unack deletes a silence via `/api/v2/silence/<id>`
- [ ] Verify close expires alert via `/api/v2/alerts`
- [ ] Verify silenceId is correctly parsed from v2 response and stored in alert attributes

🤖 Generated with [Claude Code](https://claude.com/claude-code)